### PR TITLE
Support multiple email recipients for notification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,13 @@ RUN go get github.com/gogits/go-gogs-client
 
 COPY ./cmd/gindoid /gindoid
 COPY ./tmpl /tmpl
-COPY ./hostkey /hostkey
+COPY ./hostkey /gindoid/hostkey
+COPY ./emails  /gindoid/emails
 WORKDIR /gindoid
 RUN go build
 
 VOLUME ["/doidata"]
 VOLUME ["/repos"]
 
-ENTRYPOINT ./gindoid --debug --knownhosts=/hostkey --target=/doidata --templates=/tmpl --key=$tokenkey --port=10443 --sendmail --mailto=$notifyemail --mailserver=$mailserver
+ENTRYPOINT ./gindoid --debug --knownhosts=/gindoid/hostkey --target=/doidata --templates=/tmpl --key=$tokenkey --port=10443 --sendmail --mailtofile=/gindoid/emails --mailserver=$mailserver
 EXPOSE 10443

--- a/cmd/gindoid/dstorage.go
+++ b/cmd/gindoid/dstorage.go
@@ -212,10 +212,11 @@ func (ls LocalStorage) sendMaster(dReq *DOIReq) error {
 	uuid := dReq.DOIInfo.UUID
 	doitarget := urljoin(ls.HTTPBase, uuid)
 
-	body := `Subject: New DOI registration request: %s
+	subject := fmt.Sprintf("New DOI registration request: %s", repopath)
 
-A new DOI registration request has been received.
+	body := `A new DOI registration request has been received.
 
+	Repository: %s
 	User: %s
 	Email address: %s
 	DOI XML: %s
@@ -223,5 +224,5 @@ A new DOI registration request has been received.
 	UUID: %s
 `
 	body = fmt.Sprintf(body, repopath, userlogin, useremail, xmlurl, doitarget, uuid)
-	return ls.MServer.SendMail(body)
+	return ls.MServer.SendMail(subject, body)
 }

--- a/cmd/gindoid/mailserver.go
+++ b/cmd/gindoid/mailserver.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
+	"fmt"
 	"net/smtp"
+	"os"
+	"strings"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -15,10 +19,10 @@ type MailServer struct {
 	Address   string
 	From      string
 	DoSend    bool
-	Recipient string
+	EmailList string
 }
 
-func (ms *MailServer) SendMail(body string) error {
+func (ms *MailServer) SendMail(subject, body string) error {
 	if ms.DoSend {
 		log.Debug("Preparing mail")
 		c, err := smtp.Dial(ms.Address)
@@ -32,30 +36,47 @@ func (ms *MailServer) SendMail(body string) error {
 		defer c.Close()
 		// Set the sender and recipient.
 		c.Mail(ms.From)
-		c.Rcpt(ms.Recipient)
+
+		// Recipient list is read every time a SendMail() is called.
+		// This way, the recipient list can be changed without restarting the service.
+		emailfile, err := os.Open(ms.EmailList)
+		if err != nil {
+			log.Errorf("Email file %s could not be read", ms.EmailList)
+		}
+		filereader := bufio.NewReader(emailfile)
+		message := fmt.Sprintf("From: %s\nSubject: %s", ms.From, subject)
+		for address, lerr := filereader.ReadString('\n'); lerr == nil; address, lerr = filereader.ReadString('\n') {
+			address = strings.TrimSpace(address)
+			log.Debugf("To: %s", address)
+			c.Rcpt(address)
+			message = fmt.Sprintf("%s\nTo: %s", message, address)
+		}
+
+		message = fmt.Sprintf("%s\n\n%s", message, body)
 		// Send the email body.
 		log.Debug("Sending mail")
+
 		wc, err := c.Data()
 		if err != nil {
 			log.WithFields(log.Fields{
 				"source": MAILLOG,
 				"error":  err,
-			}).Errorf("Could not write Mail")
+			}).Errorf("Could not write mail")
 			return err
 		}
 		defer wc.Close()
-		buf := bytes.NewBufferString(body)
+		buf := bytes.NewBufferString(message)
 		if _, err = buf.WriteTo(wc); err != nil {
 			log.WithFields(log.Fields{
 				"source": MAILLOG,
 				"error":  err,
-			}).Errorf("Could not write Mail")
+			}).Errorf("Could not write mail")
 		}
 		log.Debug("SendMail Done")
 	} else {
 		log.WithFields(log.Fields{
 			"source": MAILLOG,
-		}).Infof("Fake Mail to: %s, body: %s", ms.Recipient, body)
+		}).Infof("Fake mail body: %s", body)
 	}
 	return nil
 }

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -14,7 +14,7 @@ const usage = `gindoid: DOI service for preparing GIN repositories for publicati
 Usage:
   gindoid [--maxworkers=<n> --maxqueue=<n> --port=<port> --source=<url> --gitsource=<url>
            --oauthserver=<url> --target=<dir> --storeurl=<url> --mailserver=<host:port> --mailfrom=<address>
-           --mailto=<address> --doibase=<prefix> --sendmail --debug --templates=<path> --xmlurl=<url>
+           --mailtofile=<path> --doibase=<prefix> --sendmail --debug --templates=<path> --xmlurl=<url>
            --knownhosts=<path>] --key=<key>
 
 Options:
@@ -28,7 +28,7 @@ Options:
   --storeurl=<url>                 The base URL for storage [default: http://doid.gin.g-node.org/]
   --mailserver=<host:port>         The mail server address (:and port) [default: localhost:25]
   --mailfrom=<address>             The mail from address [default: no-reply@g-node.org]
-  --mailto=<address>               The mail address to send info to [default: dev@g-node.org]
+  --mailtofile=<path>              A file containing email addresses (one per line) to notify of new requests
   --doibase=<prefix>               The DOI prefix [default: 10.12751/g-node.]
   --sendmail                       Whether mail notifications should really be sent (otherwise just print them)
   --debug                          Whether debug messages shall be printed
@@ -64,16 +64,16 @@ func main() {
 	log.Debugf("doibase: %s", doibase)
 	dp := GnodeDOIProvider{APIURI: "", DOIBase: doibase}
 
-	//Setup storage
+	// Setup storage
 	mailserver := args["--mailserver"].(string)
 	mailfrom := args["--mailfrom"].(string)
-	mailto := args["--mailto"].(string)
 	sendmail := args["--sendmail"].(bool)
+	mailtofile := args["--mailtofile"].(string)
 	mServer := MailServer{
 		Address:   mailserver,
 		From:      mailfrom,
 		DoSend:    sendmail,
-		Recipient: mailto,
+		EmailList: mailtofile,
 	}
 	log.Debugf("Mail configuration: %+v", mServer)
 


### PR DESCRIPTION
Instead of setting a single email address on the command line, the
service now accepts a filepath that should contain a list of email
address (one per line). Whenever a request is received, the notification
is sent to all email addresses listed in the file.

The message has also been changed to add the From and To addresses into
the email message header and not just specified through the SMTP
commands. This puts all the recipient addresses in the email To: line,
instead of BCCing the recipients.

The file is read every time a message is about to be sent, so the
recipients can be changed without restarting the service.