### PR TITLE
GOGS user info struct and new verification method

### DIFF
--- a/cmd/gindoid/dstorage.go
+++ b/cmd/gindoid/dstorage.go
@@ -271,8 +271,8 @@ func (ls LocalStorage) sendMaster(dReq *DOIReq) error {
 	}
 
 	repopath := dReq.URI
-	userlogin := dReq.User.MainOId.Login
-	useremail := dReq.User.MainOId.Account.Email.Email
+	userlogin := dReq.OAuthLogin
+	useremail := dReq.User.Email
 	xmlurl := ls.getSCP(dReq)
 	uuid := dReq.DOIInfo.UUID
 	doitarget := urljoin(ls.HTTPBase, uuid)

--- a/cmd/gindoid/gindoi.go
+++ b/cmd/gindoid/gindoi.go
@@ -5,7 +5,7 @@ import (
 	"html/template"
 	"regexp"
 
-	"github.com/G-Node/gin-core/gin"
+	gogs "github.com/gogits/go-gogs-client"
 )
 
 const (
@@ -48,15 +48,9 @@ const (
 	lpMakeXML    = "MakeXML"
 )
 
-type DOIUser struct {
-	Name       string
-	Identities []OAuthIdentity
-	MainOId    OAuthIdentity
-}
-
 type DOIReq struct {
 	URI           string
-	User          DOIUser
+	User          gogs.User
 	OAuthLogin    string
 	Token         string
 	Message       template.HTML
@@ -64,17 +58,12 @@ type DOIReq struct {
 	ErrorMessages []string
 }
 
-type OAuthIdentity struct {
-	gin.Account
-	Token string
-}
-
 // DOIJob holds the attributes needed to perform unit of work.
 type DOIJob struct {
 	Name    string
 	Source  string
 	Storage LocalStorage
-	User    OAuthIdentity
+	User    gogs.User
 	Request DOIReq
 	Key     rsa.PrivateKey
 }

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -106,11 +106,10 @@ func main() {
 	log.Debugf("LocalStorage configuration: %+v", storage)
 
 	// setup authentication
-	oAuthAddress := libgin.ReadConf("oauthserver")
 	op := OAuthProvider{
-		URI:      fmt.Sprintf("%s/api/v1/user", oAuthAddress),
+		URI:      fmt.Sprintf("%s/api/v1/user", ginurl),
 		TokenURL: "",
-		KeyURL:   fmt.Sprintf("%s/api/v1/user/keys", oAuthAddress),
+		KeyURL:   fmt.Sprintf("%s/api/v1/user/keys", ginurl),
 	}
 	log.Debugf("OAuth configuration: %+v", op)
 

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -204,10 +204,10 @@ func InitDOIJob(w http.ResponseWriter, r *http.Request, ds *DataSource, op *OAut
 	// If any of the values is missing, render invalid request page
 	if len(URI) == 0 || len(username) == 0 || len(enctoken) == 0 {
 		log.WithFields(log.Fields{
-			"source":   "InitDOIJob",
-			"URI":      URI,
-			"username": username,
-			"token":    enctoken,
+			"source":       "InitDOIJob",
+			"URI":          URI,
+			"username":     username,
+			"verification": enctoken,
 		}).Error("Invalid request: missing fields in query string")
 		w.WriteHeader(http.StatusBadRequest)
 		dReq.Message = template.HTML(msgInvalidRequest)
@@ -221,10 +221,10 @@ func InitDOIJob(w http.ResponseWriter, r *http.Request, ds *DataSource, op *OAut
 	// Check verification string
 	if !verifyRequest(URI, username, enctoken, key) {
 		log.WithFields(log.Fields{
-			"source":   "InitDOIJob",
-			"URI":      URI,
-			"username": username,
-			"token":    enctoken,
+			"source":       "InitDOIJob",
+			"URI":          URI,
+			"username":     username,
+			"verification": enctoken,
 		}).Error("Invalid request: failed to verify")
 		w.WriteHeader(http.StatusBadRequest)
 		dReq.Message = template.HTML(msgInvalidRequest)

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -22,11 +22,6 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// Check the current user. Return a user if logged in
-func loggedInUser(r *http.Request, pr *OAuthProvider) (*DOIUser, error) {
-	return &DOIUser{}, nil
-}
-
 func readBody(r *http.Request) (*string, error) {
 	body, err := ioutil.ReadAll(r.Body)
 	x := string(body)
@@ -115,28 +110,9 @@ func DoDOIJob(w http.ResponseWriter, r *http.Request, jobQueue chan DOIJob, stor
 		"source":  "DoDOIJob",
 	}).Debug("Unmarshaled a DOI request")
 
-	ok, err := op.ValidateToken(dReq.OAuthLogin, dReq.Token)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"request": fmt.Sprintf("%+v", dReq),
-			"source":  "DoDOIJob",
-			"error":   err,
-		}).Debug("User authentication Failed")
-		dReq.Message = template.HTML(msgNotLoggedIn)
-		w.WriteHeader(http.StatusUnauthorized)
-		return
-	}
-	if !ok {
-		log.WithFields(log.Fields{
-			"request": fmt.Sprintf("%+v", dReq),
-			"source":  "DoDOIJob",
-		}).Debug("Token not valid")
-		dReq.Message = template.HTML(msgNotLoggedIn)
-		w.WriteHeader(http.StatusUnauthorized)
-		return
-	}
+	ds := storage.GetDataSource()
 
-	user, err := op.getUser(dReq.OAuthLogin, dReq.Token)
+	user, err := ds.session.RequestAccount(dReq.OAuthLogin)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"request": fmt.Sprintf("%+v", dReq),
@@ -147,10 +123,9 @@ func DoDOIJob(w http.ResponseWriter, r *http.Request, jobQueue chan DOIJob, stor
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
-	dReq.User = DOIUser{MainOId: user}
+	dReq.User = user
 	// TODO Error checking
-	ds := storage.GetDataSource()
-	uuid, _ := ds.MakeUUID(dReq.URI, user)
+	uuid, _ := ds.MakeUUID(dReq.URI)
 	ok, doiInfo := ds.ValidDOIFile(dReq.URI, user)
 	if !ok {
 		w.WriteHeader(http.StatusBadRequest)
@@ -171,11 +146,8 @@ func DoDOIJob(w http.ResponseWriter, r *http.Request, jobQueue chan DOIJob, stor
 		}).Error("Could not Authorize Pull")
 		// Notify via email
 		subject := "[GIN-DOI] Internal server error"
-		email := ""
-		if user.Account.Email != nil {
-			email = (*user.Account.Email).Email
-		}
-		name := fmt.Sprintf("%s (%s %s: %s)", user.Account.Login, user.Account.FirstName, user.Account.LastName, email)
+		email := user.Email
+		name := fmt.Sprintf("%s (%s: %s)", user.UserName, user.FullName, email)
 		message := fmt.Sprintf("An internal error occurred while preparing a registration request for repository\n\t%s\nby user\n\t%s\n\nCould not authorise pull: %v", dReq.URI, name, err)
 		storage.MServer.SendMail(subject, message)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -220,7 +192,7 @@ func InitDOIJob(w http.ResponseWriter, r *http.Request, ds *DataSource, op *OAut
 	}
 
 	URI := r.Form.Get("repo")
-	enctoken := r.Form.Get("token")
+	enctoken := r.Form.Get("verification")
 	username := r.Form.Get("user")
 
 	log.Infof("Got request: [URI: %s] [username: %s] [Encrypted token: %s]", URI, username, enctoken)
@@ -243,51 +215,25 @@ func InitDOIJob(w http.ResponseWriter, r *http.Request, ds *DataSource, op *OAut
 		return
 	}
 
-	// If the token fails to decrypt, render invalid request page
-	token, err := Decrypt([]byte(key), enctoken)
-	if err != nil {
+	dReq.URI = URI
+	dReq.OAuthLogin = username
+
+	// Check verification string
+	if !verifyRequest(URI, username, enctoken, key) {
 		log.WithFields(log.Fields{
 			"source":   "InitDOIJob",
 			"URI":      URI,
 			"username": username,
 			"token":    enctoken,
-		}).Error("Invalid request: failed to decrypt token")
+		}).Error("Invalid request: failed to verify")
 		w.WriteHeader(http.StatusBadRequest)
 		dReq.Message = template.HTML(msgInvalidRequest)
 		t.Execute(w, dReq)
 		return
 	}
 
-	dReq.URI = URI
-	dReq.OAuthLogin = username
-	dReq.Token = token
-
-	// test user login
-	ok, err := op.ValidateToken(username, token)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"request": fmt.Sprintf("%+v", dReq),
-			"source":  "InitDOIJob",
-			"error":   err,
-		}).Debug("User authentication Failed")
-		dReq.Message = template.HTML(msgNotLoggedIn)
-		w.WriteHeader(http.StatusOK)
-		return
-	}
-
-	if !ok {
-		log.WithFields(log.Fields{
-			"request": fmt.Sprintf("%+v", dReq),
-			"source":  "InitDOIJob",
-		}).Debug("Token not valid")
-		dReq.Message = template.HTML(msgNotLoggedIn)
-		w.WriteHeader(http.StatusOK)
-		t.Execute(w, dReq)
-		return
-	}
-
 	// get user
-	user, err := op.getUser(username, token)
+	user, err := ds.session.RequestAccount(username)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"request": dReq,
@@ -433,4 +379,19 @@ func WriteSSHKeyPair(path string, PrKey *rsa.PrivateKey) (string, string, error)
 	}
 
 	return pubPath, privPath, nil
+}
+
+func verifyRequest(repo, username, verification, key string) bool {
+	plaintext, err := Decrypt([]byte(key), verification)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"source":       "verifyRequest",
+			"repo":         repo,
+			"username":     username,
+			"verification": verification,
+		}).Error("Invalid request: failed to decrypt verification string")
+		return false
+	}
+
+	return plaintext == repo+username
 }


### PR DESCRIPTION
- Working towards removing internal and old (gin) types for user information and instead using gogs structs (gogs.User).  This sets off changes all over the repository.
- Send an encrypted string that includes the username and repository (the same info in the URL query) for verification.  This is to verify that the request comes from our GIN server.

GOGS counterpart: https://github.com/G-Node/gogs/commit/19ee3ece22b86950fa27db4cbdce41bb877f96bf