### PR TITLE
Use lowercase name for repo path when zipping

### DIFF
--- a/cmd/gindoid/dstorage.go
+++ b/cmd/gindoid/dstorage.go
@@ -101,7 +101,7 @@ func cloneandzip(repopath string, jobname string, targetpath string, conf *Confi
 
 	// Uninit the annex and delete .git directory
 	repoparts := strings.SplitN(repopath, "/", 2)
-	reponame := repoparts[1]
+	reponame := strings.ToLower(repoparts[1]) // clone directory is always lowercase
 	repodir := filepath.Join(targetpath, reponame)
 	if err := derepoCloneDir(repodir); err != nil {
 		log.WithFields(log.Fields{


### PR DESCRIPTION
The clone directory is always created based on the reponame but in all
lowercase.  The zip creation would fail if there were uppercase
characters in the name.  Lowercasing the path for cleanup (annex uninit
and .git removal) and zip creation too.
Fixes #17