### PR TITLE
Fix for parsing malformed reference IDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,13 @@ sudo: required
 dist: trusty
 
 go:
- - 1.7
- - 1.8
+ - 1.12
  - tip
 
 
 install:
-  - sudo apt-get update
-  - sudo apt-get install git-annex
-  - go get github.com/Sirupsen/logrus
-  - go get github.com/docopt/docopt-go
-  - go get github.com/G-Node/gin-core/gin
-  - go get golang.org/x/crypto/ssh
-  - go get gopkg.in/yaml.v2
-
-before_script:
-  # in case of non gnode repo this will link correctly otherwise it creates a link inside the folder
-  # which should not be harmful either...
-  - ln -s  $TRAVIS_BUILD_DIR $GOPATH/src/github.com/G-Node/gin-doi
+  - go build ./cmd/gindoid
+  - ./gindoid --version
 
 script:
   - go test ./...

--- a/cmd/gindoid/datasource.go
+++ b/cmd/gindoid/datasource.go
@@ -230,6 +230,10 @@ type Reference struct {
 
 func (ref Reference) GetURL() string {
 	idparts := strings.SplitN(ref.ID, ":", 2)
+	if len(idparts) != 2 {
+		// Malformed ID (no colon)
+		return ""
+	}
 	source := idparts[0]
 	idnum := idparts[1]
 


### PR DESCRIPTION
If there's no colon in the string, idparts[] indexing would cause an error.  If there's no colon, just return an empty string for the URL.