### PR TITLE
Send email early (before starting archive job)

### DIFF
--- a/cmd/gindoid/dstorage.go
+++ b/cmd/gindoid/dstorage.go
@@ -75,8 +75,12 @@ func Put(job DOIJob) error {
 		}).Error("Could not write to the metadata file")
 		preperrors = append(preperrors, fmt.Sprintf("Failed to write the metadata XML file: %s", err))
 	}
-	dReq.ErrorMessages = preperrors
-	sendMaster(dReq, conf)
+
+	if len(preperrors) > 0 {
+		// Resend email with errors if any occurred
+		dReq.ErrorMessages = preperrors
+		sendMaster(dReq, conf)
+	}
 	return err
 }
 

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -120,9 +120,12 @@ func DoDOIJob(w http.ResponseWriter, r *http.Request, jobQueue chan DOIJob, conf
 		w.Write([]byte(fmt.Sprintf(msgAlreadyRegistered, doi, doi)))
 		return
 	}
+	// Send email notification
+	sendMaster(&dReq, conf)
+	// Add job to queue
 	job := DOIJob{Source: dReq.Repository, User: user, Request: dReq, Name: doiInfo.UUID, Config: conf}
 	jobQueue <- job
-	// Render success.
+	// Render success
 	w.WriteHeader(http.StatusCreated)
 	w.Write([]byte(fmt.Sprintf(msgServerIsArchiving, doi)))
 }


### PR DESCRIPTION
Sending the notification email before beginning the archive job is good for a couple of reasons:
- We get the notification as soon as the service knows it's valid and it doesn't have to wait for a long running job to complete.  Archive jobs can take a very long time if the repository is big (hundreds of GiB).
- If a repository causes issues (extremely large repository, an uncaught error in the archiving process, etc) that put the service in a faulty state, one which prevents sending emails, the request isn't lost.

One downside is that if any issues occur during archiving, we no longer get them in the notification email.  This is currently remedied by resending the email with error messages attached when needed.