### PR TITLE
Fix static asset loading during clone

### DIFF
--- a/cmd/gindoid/assetserver.go
+++ b/cmd/gindoid/assetserver.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"net/http"
+)
+
+type AssetFS struct {
+	fs http.FileSystem
+}
+
+func NewAssetFS(path string) AssetFS {
+	dir := http.Dir(path)
+	return AssetFS{dir}
+}
+
+// Open files but not directories. Disallows directory listing of asset directories.
+func (as AssetFS) Open(path string) (http.File, error) {
+	fp, err := as.fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	stat, err := fp.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	if stat.IsDir() {
+		return nil, err
+	}
+
+	return fp, nil
+}

--- a/cmd/gindoid/dstorage.go
+++ b/cmd/gindoid/dstorage.go
@@ -117,6 +117,7 @@ func cloneandzip(repopath string, jobname string, targetpath string, conf *Confi
 	}
 
 	// Zip
+	log.Infof("Preparing zip file for %s", jobname)
 	zipfilename := filepath.Join(targetpath, jobname+".zip")
 	zipsize, err := zip(repodir, zipfilename)
 	if err != nil {
@@ -127,6 +128,7 @@ func cloneandzip(repopath string, jobname string, targetpath string, conf *Confi
 		}).Error("Could not zip the data")
 		return -1, fmt.Errorf("Failed to create the zip file: %v", err)
 	}
+	log.Infof("Archive size: %d", zipsize)
 	return zipsize, nil
 }
 

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -69,7 +69,7 @@ func main() {
 	http.HandleFunc("/do/", func(w http.ResponseWriter, r *http.Request) {
 		DoDOIJob(w, r, jobQueue, config)
 	})
-	http.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("./assets"))))
+	http.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("/assets"))))
 
 	fmt.Printf("Listening for connections on port %d\n", config.Port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", config.Port), nil))

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -61,15 +61,24 @@ func main() {
 	dispatcher.Run(NewWorker)
 
 	// Start the HTTP handlers.
+
+	// Root redirects to storage URL (DOI listing page)
 	http.Handle("/", http.RedirectHandler(config.Storage.StoreURL, http.StatusMovedPermanently))
+
+	// register renders the info page with the registration button
 	http.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
 		log.Debugf("Got request: %s", r.URL.String())
 		InitDOIJob(w, r, config)
 	})
+
+	// do starts the registration job
 	http.HandleFunc("/do/", func(w http.ResponseWriter, r *http.Request) {
 		DoDOIJob(w, r, jobQueue, config)
 	})
-	http.Handle("/assets/", http.StripPrefix("/assets/", http.FileServer(http.Dir("/assets"))))
+
+	// assets fetches static assets using a custom FileSystem
+	assetserver := http.FileServer(NewAssetFS("/assets"))
+	http.Handle("/assets/", http.StripPrefix("/assets/", assetserver))
 
 	fmt.Printf("Listening for connections on port %d\n", config.Port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", config.Port), nil))


### PR DESCRIPTION
Using the relative path `./assets` broke asset loading when the service working directory was anywhere else, which happened cloning and zipping archives.

This PR additionally blocks directory listings in the asset directory.  Keeping it isn't an issue, but it's not a bad idea to disallow them.