### PR TITLE
DOI-based dataset directory

### DIFF
--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -121,7 +121,8 @@ func cloneAndZip(repopath string, jobname string, targetpath string, conf *Confi
 
 	// Zip
 	log.Infof("Preparing zip file for %s", jobname)
-	zipfilename := filepath.Join(targetpath, jobname+".zip")
+	// use repository name for zip filename
+	zipfilename := filepath.Join(targetpath, reponame+".zip")
 	zipsize, err := zip(repodir, zipfilename)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -121,8 +121,9 @@ func cloneAndZip(repopath string, jobname string, targetpath string, conf *Confi
 
 	// Zip
 	log.Infof("Preparing zip file for %s", jobname)
-	// use repository name for zip filename
-	zipfilename := filepath.Join(targetpath, reponame+".zip")
+	// use DOI with / replacement for zip filename
+	zipbasename := strings.ReplaceAll(jobname, "/", "-")
+	zipfilename := filepath.Join(targetpath, zipbasename+".zip")
 	zipsize, err := zip(repodir, zipfilename)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/cmd/gindoid/mail.go
+++ b/cmd/gindoid/mail.go
@@ -36,9 +36,8 @@ func notifyAdmin(dReq *DOIReq, conf *Configuration) error {
 	repopath := dReq.Repository
 	userlogin := dReq.Username
 	useremail := "" // TODO: Change when GOGS sends user email with request
-	xmlurl := fmt.Sprintf("%s/%s/doi.xml", conf.Storage.XMLURL, dReq.DOIInfo.UUID)
-	uuid := dReq.DOIInfo.UUID
-	doitarget := urljoin(conf.Storage.StoreURL, uuid)
+	xmlurl := fmt.Sprintf("%s/%s/doi.xml", conf.Storage.XMLURL, dReq.DOIInfo.DOI)
+	doitarget := urljoin(conf.Storage.StoreURL, dReq.DOIInfo.DOI)
 	repourl := fmt.Sprintf("%s/%s", conf.GIN.Session.WebAddress(), repopath)
 
 	errorlist := ""
@@ -58,11 +57,10 @@ func notifyAdmin(dReq *DOIReq, conf *Configuration) error {
 	Email address: %s
 	DOI XML: %s
 	DOI target URL: %s
-	UUID: %s
 
 %s
 `
-	body = fmt.Sprintf(body, repopath, repourl, userlogin, useremail, xmlurl, doitarget, uuid, errorlist)
+	body = fmt.Sprintf(body, repopath, repourl, userlogin, useremail, xmlurl, doitarget, errorlist)
 	return sendMail(subject, body, conf)
 }
 

--- a/cmd/gindoid/mail.go
+++ b/cmd/gindoid/mail.go
@@ -33,11 +33,16 @@ func notifyAdmin(dReq *DOIReq, conf *Configuration) error {
 		return base.ResolveReference(suffix).String()
 	}
 
+	doi := ""
+	if dReq.DOIInfo != nil {
+		doi = dReq.DOIInfo.DOI
+	}
+
 	repopath := dReq.Repository
 	userlogin := dReq.Username
 	useremail := "" // TODO: Change when GOGS sends user email with request
-	xmlurl := fmt.Sprintf("%s/%s/doi.xml", conf.Storage.XMLURL, dReq.DOIInfo.DOI)
-	doitarget := urljoin(conf.Storage.StoreURL, dReq.DOIInfo.DOI)
+	xmlurl := fmt.Sprintf("%s/%s/doi.xml", conf.Storage.XMLURL, doi)
+	doitarget := urljoin(conf.Storage.StoreURL, doi)
 	repourl := fmt.Sprintf("%s/%s", conf.GIN.Session.WebAddress(), repopath)
 
 	errorlist := ""

--- a/cmd/gindoid/reginfo.go
+++ b/cmd/gindoid/reginfo.go
@@ -15,6 +15,14 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+var UUIDMap = map[string]string{
+	"INT/multielectrode_grasp":                   "f83565d148510fede8a277f660e1a419",
+	"ajkumaraswamy/HB-PAC_disinhibitory_network": "1090f803258557299d287c4d44a541b2",
+	"steffi/Kleineidam_et_al_2017":               "f53069de4c4921a3cfa8f17d55ef98bb",
+	"Churan/Morris_et_al_Frontiers_2016":         "97bc1456d3f4bca2d945357b3ec92029",
+	"fabee/efish_locking":                        "6953bbf0087ba444b2d549b759de4a06",
+}
+
 // DOIMData holds all the metadata for a dataset that's in the process of being registered.
 type DOIMData struct {
 	Data struct {
@@ -103,14 +111,6 @@ func readFileAtURL(url string) ([]byte, error) {
 		return nil, err
 	}
 	return body, nil
-}
-
-var UUIDMap = map[string]string{
-	"INT/multielectrode_grasp":                   "f83565d148510fede8a277f660e1a419",
-	"ajkumaraswamy/HB-PAC_disinhibitory_network": "1090f803258557299d287c4d44a541b2",
-	"steffi/Kleineidam_et_al_2017":               "f53069de4c4921a3cfa8f17d55ef98bb",
-	"Churan/Morris_et_al_Frontiers_2016":         "97bc1456d3f4bca2d945357b3ec92029",
-	"fabee/efish_locking":                        "6953bbf0087ba444b2d549b759de4a06",
 }
 
 // parseDOIInfo parses the DOI registration info and returns a filled DOIRegInfo struct.

--- a/cmd/gindoid/reginfo.go
+++ b/cmd/gindoid/reginfo.go
@@ -131,9 +131,8 @@ func parseDOIInfo(infoyml []byte) (*DOIRegInfo, error) {
 		log.WithFields(log.Fields{
 			"data":    string(infoyml),
 			"doiInfo": doiInfo,
-			"error":   err,
 		}).Debug("DOI file is missing entries")
-		return &doiInfo, fmt.Errorf("DOI info is missing entries: %s", err.Error())
+		return &doiInfo, fmt.Errorf("DOI info is missing entries")
 	}
 	return &doiInfo, nil
 }

--- a/cmd/gindoid/reginfo.go
+++ b/cmd/gindoid/reginfo.go
@@ -69,21 +69,23 @@ type DOIMData struct {
 	} `json:"data"`
 }
 
-// getDOIFile requests the 'datacite.yml' from a given repository and returns the contents of the file.
-func getDOIFile(URI string, conf *Configuration) ([]byte, error) {
-	// git archive --remote=git://git.foo.com/project.git HEAD:path/to/directory filename
-	// https://github.com/go-yaml/yaml.git
-	// git@github.com:go-yaml/yaml.git
-	// TODO: config variables for path etc.
-	fetchRepoPath := fmt.Sprintf("%s/raw/master/datacite.yml", URI)
+// dataciteURL returns the full URL to a repository's datacite.yml file.
+func dataciteURL(repopath string, conf *Configuration) string {
+	fetchRepoPath := fmt.Sprintf("%s/raw/master/datacite.yml", repopath)
+	url := fmt.Sprintf("%s/%s", conf.GIN.Session.WebAddress(), fetchRepoPath)
+	return url
+}
+
+// readFileAtURL returns the contents of a file at a given URL.
+func readFileAtURL(url string) ([]byte, error) {
 	client := &http.Client{}
-	log.Debugf("Fetching datacite file from %s", fetchRepoPath)
-	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", conf.GIN.Session.WebAddress(), fetchRepoPath), nil)
+	log.Debugf("Fetching datacite file from %s", url)
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
 	resp, err := client.Do(req)
 	if err != nil {
 		// todo Try to infer what went wrong
 		log.WithFields(log.Fields{
-			"path":  fetchRepoPath,
+			"path":  url,
 			"error": err,
 		}).Debug("Could not get DOI file")
 		return nil, err
@@ -95,7 +97,7 @@ func getDOIFile(URI string, conf *Configuration) ([]byte, error) {
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"path":  fetchRepoPath,
+			"path":  url,
 			"error": err,
 		}).Debug("Could not read from received datacite.yml file")
 		return nil, err
@@ -112,20 +114,12 @@ var UUIDMap = map[string]string{
 }
 
 // parseDOIInfo parses the DOI registration info and returns a filled DOIRegInfo struct.
-func parseDOIInfo(URI string, conf *Configuration) (*DOIRegInfo, error) {
-	in, err := getDOIFile(URI, conf)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"data":  string(in),
-			"error": err,
-		}).Error("Could not get the DOI file")
-		return nil, fmt.Errorf("failed to retrieve file: %s", err.Error())
-	}
+func parseDOIInfo(infoyml []byte) (*DOIRegInfo, error) {
 	doiInfo := DOIRegInfo{}
-	err = yaml.Unmarshal(in, &doiInfo)
+	err := yaml.Unmarshal(infoyml, &doiInfo)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"data":  string(in),
+			"data":  string(infoyml),
 			"error": err,
 		}).Error("Could not unmarshal DOI file")
 		res := DOIRegInfo{}
@@ -135,7 +129,7 @@ func parseDOIInfo(URI string, conf *Configuration) (*DOIRegInfo, error) {
 	doiInfo.DateTime = time.Now()
 	if !hasValues(&doiInfo) {
 		log.WithFields(log.Fields{
-			"data":    string(in),
+			"data":    string(infoyml),
 			"doiInfo": doiInfo,
 			"error":   err,
 		}).Debug("DOI file is missing entries")

--- a/cmd/gindoid/templates.go
+++ b/cmd/gindoid/templates.go
@@ -334,7 +334,7 @@ const landingPageTmpl = `<!DOCTYPE html>
 						</tr>
 						<tr>
 							<td>DOI</td>
-							<td><a href="#" class ="ui grey label">{{.DOIInfo.DOI}}</a></td>
+							<td><a href="https://doi.org/{{.DOIInfo.DOI}}" class ="ui grey label">{{.DOIInfo.DOI}}</a></td>
 						</tr>
 						<tr>
 							<td>Citation</td>

--- a/cmd/gindoid/templates.go
+++ b/cmd/gindoid/templates.go
@@ -51,7 +51,7 @@ function doify(event) {
 			$("#warning").hide();
 		},
 		error: function (data) {
-			$("#info").html("An internal error occured while we were processing your request.  The G-Node team has been notified of the problem and will attempt to repair it and process your request.  We may contact you for further information regarding your request.  Feel free to <a href=mailto:gin@g-node.org>contact us</a> if you would like to provide more information or ask about the status of your request.");
+			$("#info").html("An internal error occurred while we were processing your request.  The G-Node team has been notified of the problem and will attempt to repair it and process your request.  We may contact you for further information regarding your request.  Feel free to <a href=mailto:gin@g-node.org>contact us</a> if you would like to provide more information or ask about the status of your request.");
 			$("#info").toggleClass("ui positive message");
 			$("#info").toggleClass("ui negative message");
 			$("#infotable").hide();

--- a/cmd/gindoid/web.go
+++ b/cmd/gindoid/web.go
@@ -61,9 +61,26 @@ func startDOIRegistration(w http.ResponseWriter, r *http.Request, jobQueue chan 
 	}
 
 	dReq := DOIReq{}
-	// TODO: Error checking
-	body, _ := ioutil.ReadAll(r.Body)
-	json.Unmarshal(body, &dReq)
+
+	// Send email notification even if the registration fails beyond this point
+	defer notifyAdmin(&dReq, conf)
+
+	// NOTE: If this function responds with an error header, the same error is
+	// rendered regardless of the type. The error is rendered by the inline
+	// 'doify' function in the requestPageTmpl template.
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		dReq.ErrorMessages = []string{"Failed to read request body. No info available."}
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	err = json.Unmarshal(body, &dReq)
+	if err != nil {
+		dReq.ErrorMessages = []string{"Failed to unmarshal request body. Some information may be missing."}
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 	log.WithFields(log.Fields{
 		"request": fmt.Sprintf("%+v", dReq),
 		"source":  "startDOIRegistration",
@@ -76,6 +93,7 @@ func startDOIRegistration(w http.ResponseWriter, r *http.Request, jobQueue chan 
 			"source":  "startDOIRegistration",
 		}).Error("Invalid request: failed to verify")
 		w.WriteHeader(http.StatusUnauthorized)
+		dReq.ErrorMessages = []string{"Failed to verify request"}
 		return
 	}
 
@@ -86,16 +104,21 @@ func startDOIRegistration(w http.ResponseWriter, r *http.Request, jobQueue chan 
 			"source":  "startDOIRegistration",
 			"error":   err,
 		}).Debug("Could not get userdata")
-		dReq.Message = template.HTML(msgNotLoggedIn)
 		w.WriteHeader(http.StatusUnauthorized)
+		dReq.ErrorMessages = []string{fmt.Sprintf("Failed to get user data: %s", err.Error())}
 		return
 	}
-	// TODO Error checking
 	uuid := makeUUID(dReq.Repository)
 	infoyml, err := readFileAtURL(dataciteURL(dReq.Repository, conf))
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		dReq.ErrorMessages = []string{fmt.Sprintf("Failed to fetch datacite.yml: %s", err.Error())}
+		return
+	}
 	doiInfo, err := parseDOIInfo(infoyml)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
+		dReq.ErrorMessages = []string{fmt.Sprintf("Failed to parse datacite.yml: %s", err.Error())}
 		return
 	}
 
@@ -107,10 +130,10 @@ func startDOIRegistration(w http.ResponseWriter, r *http.Request, jobQueue chan 
 	if isRegisteredDOI(doi) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(fmt.Sprintf(msgAlreadyRegistered, doi, doi)))
+		dReq.ErrorMessages = []string{"This DOI is already registered"}
 		return
 	}
-	// Send email notification
-	notifyAdmin(&dReq, conf)
+
 	// Add job to queue
 	job := DOIJob{Source: dReq.Repository, User: user, Request: dReq, Name: doiInfo.DOI, Config: conf}
 	jobQueue <- job

--- a/cmd/gindoid/web.go
+++ b/cmd/gindoid/web.go
@@ -93,8 +93,8 @@ func startDOIRegistration(w http.ResponseWriter, r *http.Request, jobQueue chan 
 	}
 	// TODO Error checking
 	uuid := makeUUID(dReq.Repository)
-	ok, doiInfo := validDOIFile(dReq.Repository, conf)
-	if !ok {
+	doiInfo, err := parseDOIInfo(dReq.Repository, conf)
+	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -183,7 +183,7 @@ func renderRequestPage(w http.ResponseWriter, r *http.Request, conf *Configurati
 	}
 
 	// check for doifile
-	if ok, doiInfo := validDOIFile(repository, conf); ok {
+	if doiInfo, err := parseDOIInfo(repository, conf); err == nil {
 		j, _ := json.MarshalIndent(doiInfo, "", "  ")
 		log.Debugf("Received DOI information: %s", string(j))
 		dReq.DOIInfo = doiInfo

--- a/cmd/gindoid/web.go
+++ b/cmd/gindoid/web.go
@@ -75,7 +75,6 @@ func startDOIRegistration(w http.ResponseWriter, r *http.Request, jobQueue chan 
 			"request": fmt.Sprintf("%+v", dReq),
 			"source":  "startDOIRegistration",
 		}).Error("Invalid request: failed to verify")
-		dReq.Message = template.HTML(msgInvalidRequest)
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}

--- a/cmd/gindoid/web.go
+++ b/cmd/gindoid/web.go
@@ -113,7 +113,7 @@ func startDOIRegistration(w http.ResponseWriter, r *http.Request, jobQueue chan 
 	// Send email notification
 	notifyAdmin(&dReq, conf)
 	// Add job to queue
-	job := DOIJob{Source: dReq.Repository, User: user, Request: dReq, Name: doiInfo.UUID, Config: conf}
+	job := DOIJob{Source: dReq.Repository, User: user, Request: dReq, Name: doiInfo.DOI, Config: conf}
 	jobQueue <- job
 	// Render success
 	w.WriteHeader(http.StatusCreated)


### PR DESCRIPTION
The main purpose of this PR is changing the storage directory of the registered datasets to use the DOI instead of a UUID.  Using the DOI instead of the UUID makes for nicer (and predictable)
landing page URLs.  The dataset landing pages will now be in the form `https://doid.gin.g-node.org/<DOI>`.

This also changes the zip filename to use the name of the original repository.  Using the DOI would be an issue since it contains a slash `/`.  The UUID could still be used but isn't as nice.  The repository name is (theoretically) meaningful and is also guaranteed to be a valid filename.

The PR also includes some refactoring of the DOI metadata file parsing functions.