### PR TITLE
Request result page redesign

### DIFF
--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -71,8 +71,8 @@ func main() {
 		renderRequestPage(w, r, config)
 	})
 
-	// do starts the registration job
-	http.HandleFunc("/do/", func(w http.ResponseWriter, r *http.Request) {
+	// submit starts the registration job
+	http.HandleFunc("/submit", func(w http.ResponseWriter, r *http.Request) {
 		startDOIRegistration(w, r, jobQueue, config)
 	})
 

--- a/cmd/gindoid/templates.go
+++ b/cmd/gindoid/templates.go
@@ -27,39 +27,6 @@ const requestPageTmpl = `<!DOCTYPE html>
 		<link rel="stylesheet" href="/assets/css/gogs.css">
 		<link rel="stylesheet" href="/assets/css/custom.css">
 
-		<script src="/assets/js/jquery-1.11.3.min.js"></script>
-		<script>
-			$(document).ready(function () {
-				$ = jQuery.noConflict();
-				$.ajaxSetup({cache: false});
-				$("#main").on('click', "#doify", doify);
-			});
-
-function doify(event) {
-	$(event.target).addClass("disabled");
-	$.ajax({
-		url: "/do/",
-		type: "POST",
-		contentType: "text/plain",
-		data: "{\"repository\":\"{{.Repository}}\",\"username\":\"{{.Username}}\",\"verification\":\"{{.Verification}}\"}",
-		dataType: "text",
-		success: function (data) {
-			$("#info").html($.parseHTML(data));
-			$("#info").toggleClass("ui positive message");
-			$("#info").toggleClass("ui info icon message");
-			$("#infotable").hide();
-			$("#warning").hide();
-		},
-		error: function (data) {
-			$("#info").html("An internal error occurred while we were processing your request.  The G-Node team has been notified of the problem and will attempt to repair it and process your request.  We may contact you for further information regarding your request.  Feel free to <a href=mailto:gin@g-node.org>contact us</a> if you would like to provide more information or ask about the status of your request.");
-			$("#info").toggleClass("ui positive message");
-			$("#info").toggleClass("ui negative message");
-			$("#infotable").hide();
-			$("#warning").hide();
-		}
-	});
-}
-		</script>
 		<title>GIN-DOI</title>
 
 		<meta name="theme-color" content="#ffffff">
@@ -196,7 +163,12 @@ function doify(event) {
 									<p><b>All files and data in the repository will be part of the public archive!</b></p>
 								</div>
 							</div>
-							<div class="ui primary button" id="doify">Request DOI Now</div>
+							<form action="/do" method="post">
+								<input type="hidden" id="repository" name="repository" value="{{.Repository}}">
+								<input type="hidden" id="username" name="username" value="{{.Username}}">
+								<input type="hidden" id="verification" name="verification" value="{{.Verification}}">
+								<button class="ui primary button" type="submit">Request DOI Now</button>
+							</form>
 						{{else}}
 							<div class="ui warning message">
 								<div><b>DOI request failed</b>

--- a/cmd/gindoid/templates.go
+++ b/cmd/gindoid/templates.go
@@ -163,7 +163,7 @@ const requestPageTmpl = `<!DOCTYPE html>
 									<p><b>All files and data in the repository will be part of the public archive!</b></p>
 								</div>
 							</div>
-							<form action="/do" method="post">
+							<form action="/submit" method="post">
 								<input type="hidden" id="repository" name="repository" value="{{.Repository}}">
 								<input type="hidden" id="username" name="username" value="{{.Username}}">
 								<input type="hidden" id="verification" name="verification" value="{{.Verification}}">

--- a/cmd/gindoid/templates.go
+++ b/cmd/gindoid/templates.go
@@ -204,6 +204,100 @@ const requestPageTmpl = `<!DOCTYPE html>
 	</body>
 </html>`
 
+const requestResultTmpl = `<!DOCTYPE html>
+<html lang="en">
+	<head data-suburl="">
+
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+		<meta name="robots" content="noindex,nofollow">
+
+
+		<meta name="author" content="G-Node">
+		<meta name="description" content="Info">
+		<meta name="keywords" content="gin, data, sharing, science git">
+
+		<meta property="og:url" content="https://gin.g-node.org/G-Node/Info">
+		<meta property="og:type" content="object">
+		<meta property="og:title" content="G-Node/Info">
+		<meta property="og:description" content="">
+		<meta property="og:image" content="https://gin.g-node.org/avatars/18">
+
+
+		<link rel="shortcut icon" href="/assets/img/favicon.png">
+		<link rel="stylesheet" href="/assets/octicons-4.3.0/octicons.min.css">
+		<link rel="stylesheet" href="/assets/css/semantic-2.3.1.min.css">
+		<link rel="stylesheet" href="/assets/css/gogs.css">
+		<link rel="stylesheet" href="/assets/css/custom.css">
+
+		<title>GIN-DOI</title>
+
+		<meta name="theme-color" content="#ffffff">
+	</head>
+	<body>
+		<div class="full-height" id="main">
+			<div class="following bar light">
+				<div class="ui container">
+					<div class="ui grid">
+						<div class="column">
+							<div class="ui top secondary menu">
+								<a class="item brand" href="https://gin.g-node.org/">
+									<img class="ui mini image" src="/assets/img/favicon.png">
+								</a>
+								<a class="item active" href="https://gin.g-node.org/{{.Request.Repository}}">Back to GIN</a>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div>
+				<div class="ui vertically padded grid head">
+					<div class="column center">
+						<h1>Welcome to the GIN DOI service
+							<i class="mega-octicon octicon octicon-squirrel"></i>
+						</h1>
+					</div>
+				</div>
+
+				<div class="ui container">
+					<div class="ui {{.Level}} message">
+				{{ if .Success }}
+						<div><b>DOI request submitted</b></div>
+				{{ else }}
+						<div><b>DOI request failed</b></div>
+				{{ end }}
+					</div>
+					<div class="ui info message">
+						{{.Message}}
+					</div>
+				</div>
+			</div>
+		</div>
+		<footer>
+			<div class="ui container">
+				<div class="ui center links item brand footertext">
+					<a href="http://www.g-node.org"><img class="ui mini footericon" src="https://projects.g-node.org/assets/gnode-bootstrap-theme/1.2.0-snapshot/img/gnode-icon-50x50-transparent.png"/>© G-Node, 2016-2019</a>
+					<a href="https://gin.g-node.org/G-Node/Info/wiki/about">About</a>
+					<a href="https://gin.g-node.org/G-Node/Info/wiki/imprint">Imprint</a>
+					<a href="https://gin.g-node.org/G-Node/Info/wiki/contact">Contact</a>
+					<a href="https://gin.g-node.org/G-Node/Info/wiki/Terms+of+Use">Terms of Use</a>
+					<a href="https://gin.g-node.org/G-Node/Info/wiki/Datenschutz">Datenschutz</a>
+
+				</div>
+				<div class="ui center links item brand footertext">
+					<span>Powered by:      <a href="https://github.com/gogs/gogs"><img class="ui mini footericon" src="/assets/img/gogs.svg"/></a>         </span>
+					<span>Hosted by:       <a href="https://neuro.bio.lmu.de"><img class="ui mini footericon" src="/assets/img/lmu.png"/></a>          </span>
+					<span>Funded by:       <a href="https://www.bmbf.de"><img class="ui mini footericon" src="/assets/img/bmbf.png"/></a>         </span>
+					<span>Registered with: <a href="https://doi.org/10.17616/R3SX9N"><img class="ui mini footericon" src="/assets/img/re3.png"/></a>          </span>
+					<span>Recommended by:  <a href="https://www.nature.com/sdata/policies/repositories#neurosci"><img class="ui mini footericon" src="/assets/img/sdatarecbadge.jpg"/><a href="https://journals.plos.org/plosone/s/data-availability#loc-neuroscience"><img class="ui mini footericon" src="/assets/img/sm_plos-logo-sm.png"/></a></span>
+				</div>
+			</div>
+		</footer>
+
+	</body>
+</html>`
+
 const landingPageTmpl = `<!DOCTYPE html>
 <html lang="en">
 	<head>

--- a/cmd/gindoid/web.go
+++ b/cmd/gindoid/web.go
@@ -23,7 +23,7 @@ const (
 						</div>`
 	msgServerIsArchiving = `<div class="content">
 			<div class="header">The DOI server has started archiving your repository.</div>
-		We will try to register the following DOI for your dataset:<br>
+		We have reserved the following DOI for your dataset:<br>
 		<div class ="ui label label-default">%s</div><br>
 		In rare cases the final DOI might be different.<br>
 		Please note that the final step in the registration process requires us to manually review your request.
@@ -44,6 +44,8 @@ const (
 	msgInvalidReference = "A specified Reference is not valid. Please provide the name and type of the reference."
 	msgBadEncoding      = `There was an issue with the content of the DOI file (datacite.yml). This might mean that the encoding is wrong. Please see <a href="https://gin.g-node.org/G-Node/Info/wiki/DOIfile">the DOI guide</a> for detailed instructions or contact gin@g-node.org for assistance.`
 
+	msgSubmitError  = "An internal error occurred while we were processing your request.  The G-Node team has been notified of the problem and will attempt to repair it and process your request.  We may contact you for further information regarding your request.  Feel free to <a href=mailto:gin@g-node.org>contact us</a> if you would like to provide more information or ask about the status of your request."
+	msgSubmitFailed = "An internal error occurred while we were processing your request.  Your request was not submitted.  Please <a href=mailto:gin@g-node.org>contact us</a> for further assistance."
 	// Log Prefixes
 	lpAuth    = "GinOAP"
 	lpStorage = "Storage"

--- a/cmd/gindoid/web.go
+++ b/cmd/gindoid/web.go
@@ -61,19 +61,18 @@ type reqResultData struct {
 }
 
 // renderResult renders the results of a registration request using the
-// 'requestResultTmpl' template. It returns an error if there was a problem
-// rendering the template.
-func renderResult(w http.ResponseWriter, resData *reqResultData) error {
+// 'requestResultTmpl' template. If it fails to parse the template, it renders
+// the Message from the result data in plain HTML.
+func renderResult(w http.ResponseWriter, resData *reqResultData) {
 	tmpl, err := template.New("requestresult").Parse(requestResultTmpl)
 	if err != nil {
 		log.Errorf("Failed to parse template: %s", err.Error())
 		log.Errorf("Request data: %+v", resData)
 		// failed to render result template; just show the message wrapped in html tags
 		w.Write([]byte("<html>" + resData.Message + "</html>"))
-		return err
+		return
 	}
 	tmpl.Execute(w, &resData)
-	return nil
 }
 
 // startDOIRegistration starts the DOI registration process by authenticating

--- a/cmd/gindoid/web.go
+++ b/cmd/gindoid/web.go
@@ -43,7 +43,7 @@ const (
 	msgBadEncoding      = `There was an issue with the content of the DOI file (datacite.yml). This might mean that the encoding is wrong. Please see <a href="https://gin.g-node.org/G-Node/Info/wiki/DOIfile">the DOI guide</a> for detailed instructions or contact gin@g-node.org for assistance.`
 
 	msgSubmitError     = "An internal error occurred while we were processing your request.  The G-Node team has been notified of the problem and will attempt to repair it and process your request.  We may contact you for further information regarding your request.  Feel free to <a href=mailto:gin@g-node.org>contact us</a> if you would like to provide more information or ask about the status of your request."
-	msgSubmitFailed    = "An internal error occurred while we were processing your request.  Your request was not submitted.  Please <a href=mailto:gin@g-node.org>contact us</a> for further assistance."
+	msgSubmitFailed    = "An internal error occurred while we were processing your request.  Your request was not submitted and the service failed to notify the G-Node team.  Please <a href=mailto:gin@g-node.org>contact us</a> to report this error."
 	msgNoTemplateError = "An internal error occurred while we were processing your request.  The G-Node team has been notified of the problem and will attempt to repair it and process your request.  We may contact you for further information regarding your request.  Feel free to contact us at gin@g-node.org if you would like to provide more information or ask about the status of your request."
 	// Log Prefixes
 	lpAuth    = "GinOAP"

--- a/cmd/gindoid/web.go
+++ b/cmd/gindoid/web.go
@@ -13,14 +13,12 @@ const (
 	msgInvalidRequest    = `Invalid request data received.  Please note that requests should only be submitted through repository pages on <a href="https://gin.g-node.org">GIN</a>.  If you followed the instructions in the <a href="https://gin.g-node.org/G-Node/Info/wiki/DOIfile">DOI registration guide</a> and arrived at this error page, please <a href="mailto:gin@g-node.org">contact us</a> for assistance.`
 	msgInvalidDOI        = `The DOI file was not valid. Please see <a href="https://gin.g-node.org/G-Node/Info/wiki/DOIfile">the DOI guide</a> for detailed instructions. `
 	msgInvalidURI        = "Please provide a valid repository URI"
-	msgAlreadyRegistered = `<i class="info icon"></i>
-						<div class="content">
-							<div class="header"> A DOI is already registered for your dataset.</div>
-							Your DOI is: <br>
-								<div class ="ui label label-default"><a href="https://doi.org/%s">%s</a>
-							</div>.
-							If this is incorrect or you would like to register a new version of your dataset, please <a href=mailto:gin@g-node.org>contact us</a>.
-						</div>`
+	msgAlreadyRegistered = `<div class="content">
+								<div class="header"> A DOI is already registered for your dataset.</div>
+								Your DOI is: <br>
+								<div class ="ui label label-default"><a href="https://doi.org/%s">%s</a></div></br>
+								If this is incorrect or you would like to register a new version of your dataset, please <a href=mailto:gin@g-node.org>contact us</a>.
+							</div>`
 	msgServerIsArchiving = `<div class="content">
 			<div class="header">The DOI server has started archiving your repository.</div>
 		We have reserved the following DOI for your dataset:<br>

--- a/cmd/gindoid/web.go
+++ b/cmd/gindoid/web.go
@@ -301,6 +301,10 @@ func renderRequestPage(w http.ResponseWriter, r *http.Request, conf *Configurati
 // verifyRequest decrypts the verification string and compares it with the
 // received data.
 func verifyRequest(repo, username, verification, key string) bool {
+	if repo == "" || username == "" || verification == "" {
+		// missing data; don't bother
+		return false
+	}
 	plaintext, err := decrypt([]byte(key), verification)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/cmd/gindoid/web.go
+++ b/cmd/gindoid/web.go
@@ -115,22 +115,21 @@ func startDOIRegistration(w http.ResponseWriter, r *http.Request, jobQueue chan 
 		return
 	}
 
+	// everything beyond this point should trigger an email notification
 	defer func() {
 		err := notifyAdmin(&dReq, conf)
 		if err != nil {
 			// Email send failed
 			// Log the error
-			log.WithFields(log.Fields{
-				"request": fmt.Sprintf("%+v", dReq),
-				"source":  "startDOIRegistration",
-			}).Error("Failed to send notification email")
+			log.Errorf("Failed to send notification email: %s", err.Error())
+			log.Errorf("Request data: %+v", dReq)
 			// Ask the user to contact us
 			resData.Success = false
 			resData.Level = "error"
 			resData.Message = template.HTML(msgSubmitFailed)
 		}
 		// Render the result
-		// tmpl.Execute(w, &resData)
+		renderResult(w, &resData)
 	}()
 
 	user, err := conf.GIN.Session.RequestAccount(dReq.Username)


### PR DESCRIPTION
This PR redesigns the way the submission page and response to the submission works.

- Previously, the Request DOI Now button was handled by an embedded javascript function that called the 'do/' route on the service, received a response (success or error) and a message and displayed the message.  Now the route (renamed to `submit/`) renders a response using a new template.
- Email failures: If the notification email sending fails (misconfigured mail server address, or the mail server is down), the user will be instructed to contact us.
- Template failures: If the response template fails to be parsed (which shouldn't happen, since we now embed the templates in code), the message will be rendered in plain `<html>...</html>` tags, so the message is not lost.

Note: Whenever I change a log message, I change it to plain old `log.Debug()` or `log.Error()` calls instead of the logrus `WithFields()` function.  I want to move away from logrus and just use the standard library logger.  We don't have a lot of heavy logging going on and using logrus is both overkill and an extra (pretty large) dependency.