### PR TITLE
Fix: ZIP file link in landing page template

### DIFF
--- a/cmd/gindoid/reginfo.go
+++ b/cmd/gindoid/reginfo.go
@@ -141,6 +141,7 @@ type DOIRegInfo struct {
 	Missing      []string
 	DOI          string
 	UUID         string
+	FileName     string
 	FileSize     string
 	Title        string
 	Authors      []Author
@@ -298,7 +299,6 @@ type DOIReq struct {
 func (d *DOIReq) GetDOIURI() string {
 	var re = regexp.MustCompile(`(.+)\/`)
 	return string(re.ReplaceAll([]byte(d.Repository), []byte("doi/")))
-
 }
 
 func (d *DOIReq) AsHTML() template.HTML {

--- a/cmd/gindoid/templates.go
+++ b/cmd/gindoid/templates.go
@@ -394,7 +394,7 @@ const landingPageTmpl = `<!DOCTYPE html>
 							<td>Data</td>
 							<td>
 								This dataset can be browsed online <a href="https://gin.g-node.org/{{.GetDOIURI}}">here</a> or downloaded as a
-								<a href="{{.DOIInfo.UUID}}.zip">zip archive ({{.DOIInfo.FileSize}})</a>.
+								<a href="{{.DOIInfo.FileName}}">zip archive ({{.DOIInfo.FileSize}})</a>.
 								The current version of the dataset repository, possibly with updates, can be found <a href="https://gin.g-node.org/{{.Repository}}">here</a>.
 							</td>
 						</tr>


### PR DESCRIPTION
Landing page was still being rendered linking to old zip file format (UUID).  cloneAndZip() function now returns filename (with .zip extension) for the created archive, which gets added to the DOIInfo struct, and the template uses it in the template. 