### PR TITLE
Use underscore instead of dash in zip filename

### DIFF
--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -123,7 +123,7 @@ func cloneAndZip(repopath string, jobname string, targetpath string, conf *Confi
 	// Zip
 	log.Infof("Preparing zip file for %s", jobname)
 	// use DOI with / replacement for zip filename
-	zipbasename := strings.ReplaceAll(jobname, "/", "-") + ".zip"
+	zipbasename := strings.ReplaceAll(jobname, "/", "_") + ".zip"
 	zipfilename := filepath.Join(targetpath, zipbasename)
 	zipsize, err := zip(repodir, zipfilename)
 	if err != nil {


### PR DESCRIPTION
Replacing the / with _ instead of - for the DOI that's transformed to a safe filename.

Requested by Thomas.