### PR TITLE
Funding ref split

### DIFF
--- a/cmd/gindoid/reginfo.go
+++ b/cmd/gindoid/reginfo.go
@@ -169,6 +169,8 @@ func renderXML(doiInfo *libgin.DOIRegInfo) (string, error) {
 		"ReferenceDescription": ReferenceDescription,
 		"ReferenceID":          ReferenceID,
 		"ReferenceSource":      ReferenceSource,
+		"FunderName":           FunderName,
+		"AwardNumber":          AwardNumber,
 	}
 	tmpl, err := txttemplate.New("doixml").Funcs(tmplfuncs).Parse(doiXML)
 	if err != nil {

--- a/cmd/gindoid/templates.go
+++ b/cmd/gindoid/templates.go
@@ -468,11 +468,11 @@ const doiXML = `<?xml version="1.0" encoding="UTF-8"?>
      <subject>{{EscXML $kw}}</subject>{{end}}
   </subjects>{{end}}
   {{if .References}}<relatedIdentifiers>{{range $index, $ref := .References}}
-    <relatedIdentifier relatedIdentifierType="{{ReferenceSource $ref}}" relationType="{{$ref.Reftype}}">{{ReferenceID $ref}}</relatedIdentifier>
-  {{end}}</relatedIdentifiers>{{end}}
+    <relatedIdentifier relatedIdentifierType="{{ReferenceSource $ref}}" relationType="{{$ref.Reftype}}">{{ReferenceID $ref}}</relatedIdentifier>{{end}}
+  </relatedIdentifiers>{{end}}
   {{if .Funding}}<fundingReferences>{{range $index, $fu := .Funding}}
-  <fundingReference><funderName>{{EscXML $fu}}</funderName></fundingReference>{{end}}
-</fundingReferences>{{end}}
+    <fundingReference><funderName>{{EscXML FunderName $fu}}</funderName><awardNumber>{{EscXML AwardNumber $fu}}</awardNumber></fundingReference>{{end}}
+  </fundingReferences>{{end}}
   <contributors>
     <contributor contributorType="HostingInstitution">
       <contributorName>German Neuroinformatics Node</contributorName>

--- a/cmd/gindoid/templates.go
+++ b/cmd/gindoid/templates.go
@@ -471,7 +471,7 @@ const doiXML = `<?xml version="1.0" encoding="UTF-8"?>
     <relatedIdentifier relatedIdentifierType="{{ReferenceSource $ref}}" relationType="{{$ref.Reftype}}">{{ReferenceID $ref}}</relatedIdentifier>{{end}}
   </relatedIdentifiers>{{end}}
   {{if .Funding}}<fundingReferences>{{range $index, $fu := .Funding}}
-    <fundingReference><funderName>{{EscXML FunderName $fu}}</funderName><awardNumber>{{EscXML AwardNumber $fu}}</awardNumber></fundingReference>{{end}}
+    <fundingReference><funderName>{{FunderName $fu}}</funderName><awardNumber>{{AwardNumber $fu}}</awardNumber></fundingReference>{{end}}
   </fundingReferences>{{end}}
   <contributors>
     <contributor contributorType="HostingInstitution">

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -122,3 +122,25 @@ func ReferenceID(ref libgin.Reference) string {
 	}
 	return idparts[1]
 }
+
+// FunderName splits the funder name from a funding string of the form <FunderName>, <AwardNumber>.
+// This is a utility function for the doi.xml template.
+func FunderName(fundref string) string {
+	fuparts := strings.SplitN(fundref, ",", 2)
+	if len(fuparts) != 2 {
+		// No comma, return as is
+		return fundref
+	}
+	return strings.TrimSpace(fuparts[0])
+}
+
+// AwardNumber splits the award number from a funding string of the form <FunderName>, <AwardNumber>.
+// This is a utility function for the doi.xml template.
+func AwardNumber(fundref string) string {
+	fuparts := strings.SplitN(fundref, ",", 2)
+	if len(fuparts) != 2 {
+		// No comma, return empty
+		return ""
+	}
+	return strings.TrimSpace(fuparts[1])
+}

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -96,7 +96,8 @@ func ReferenceDescription(ref libgin.Reference) string {
 	if !strings.HasSuffix(namecitation, ".") {
 		namecitation += "."
 	}
-	return fmt.Sprintf("%s: %s (%s)", ref.Reftype, namecitation, ref.ID)
+	refDesc := fmt.Sprintf("%s: %s (%s)", ref.Reftype, namecitation, ref.ID)
+	return EscXML(refDesc)
 }
 
 // ReferenceSource splits the source type from a reference string of the form <source>:<ID>
@@ -108,7 +109,7 @@ func ReferenceSource(ref libgin.Reference) string {
 		// No source type
 		return ""
 	}
-	return idparts[0]
+	return EscXML(idparts[0])
 }
 
 // ReferenceID splits the ID from a reference string of the form <source>:<ID>
@@ -118,9 +119,9 @@ func ReferenceID(ref libgin.Reference) string {
 	if len(idparts) != 2 {
 		// Malformed ID (no colon)
 		// No source type
-		return idparts[0]
+		return EscXML(idparts[0])
 	}
-	return idparts[1]
+	return EscXML(idparts[1])
 }
 
 // FunderName splits the funder name from a funding string of the form <FunderName>, <AwardNumber>.
@@ -129,9 +130,9 @@ func FunderName(fundref string) string {
 	fuparts := strings.SplitN(fundref, ",", 2)
 	if len(fuparts) != 2 {
 		// No comma, return as is
-		return fundref
+		return EscXML(fundref)
 	}
-	return strings.TrimSpace(fuparts[0])
+	return EscXML(strings.TrimSpace(fuparts[0]))
 }
 
 // AwardNumber splits the award number from a funding string of the form <FunderName>, <AwardNumber>.
@@ -142,5 +143,5 @@ func AwardNumber(fundref string) string {
 		// No comma, return empty
 		return ""
 	}
-	return strings.TrimSpace(fuparts[1])
+	return EscXML(strings.TrimSpace(fuparts[1]))
 }


### PR DESCRIPTION
The datacite.yml template requests funding references to separate funder name from award number with a comma.  When rendering the XML file, we can split on comma to populate the funding field more completely.

If there are no commas, the complete reference is returned only for the funder name field, like we did before this change.