### PR TITLE
Generate new DOIs randomly

### DIFF
--- a/cmd/gindoid/genhtml.go
+++ b/cmd/gindoid/genhtml.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/G-Node/libgin/libgin"
-	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 )
 
@@ -126,31 +125,4 @@ func fetchAndParse(ginurl string, repopath string) (*libgin.RepositoryYAML, erro
 		return nil, fmt.Errorf("Failed to parse metadata for repository %q\n", repopath)
 	}
 	return doiInfo, nil
-}
-
-// getArchiveSize checks if the DOI is already registered and if it is,
-// retrieves the size of the dataset archive.
-// If it fails in any way, it returns an empty string.
-func getArchiveSize(storeurl string, doibase string, uuid string) string {
-	// try both new (doi-based) and old (uuid-based) zip filenames since we
-	// currently have both on the server
-
-	doi := doibase + uuid[:6]
-	zipfnames := []string{
-		strings.ReplaceAll(doi, "/", "_") + ".zip",
-		uuid + ".zip",
-	}
-
-	for _, zipfname := range zipfnames {
-		zipurl, _ := url.Parse(storeurl)
-		zipurl.Path = path.Join(doi, zipfname)
-
-		size, err := libgin.GetArchiveSize(zipurl.String())
-		if err != nil {
-			fmt.Printf("Request for archive %q failed: %s\n", zipurl.String(), err.Error())
-			continue
-		}
-		return humanize.IBytes(uint64(size))
-	}
-	return ""
 }

--- a/cmd/gindoid/web.go
+++ b/cmd/gindoid/web.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"html/template"
 	"log"
+	"math/rand"
 	"net/http"
 	"strings"
+	"time"
 
 	gdtmpl "github.com/G-Node/gin-doi/templates"
 	"github.com/G-Node/libgin/libgin"
@@ -80,6 +82,21 @@ func renderResult(w http.ResponseWriter, resData *reqResultData) {
 	}
 }
 
+const ALNUM = "1234567890abcdefghijklmnopqrstuvwxyz"
+
+// randAlnum returns a random alphanumeric (lowercase, latin) string of length 'n'.
+func randAlnum(n int) string {
+	N := len(ALNUM)
+
+	chrs := make([]byte, n)
+	rand.Seed(time.Now().UnixNano())
+	for idx := range chrs {
+		chrs[idx] = ALNUM[rand.Intn(N)]
+	}
+
+	return string(chrs)
+}
+
 // startDOIRegistration starts the DOI registration process by authenticating
 // with the GIN server and adding a new DOIJob to the jobQueue.
 func startDOIRegistration(w http.ResponseWriter, r *http.Request, jobQueue chan *RegistrationJob, conf *Configuration) {
@@ -127,20 +144,6 @@ func startDOIRegistration(w http.ResponseWriter, r *http.Request, jobQueue chan 
 	// otherwise, unexpected repository name, so don't set ForkRepository and
 	// the cloner will notify
 
-	// calculate DOI
-	uuid := makeUUID(regJob.Metadata.SourceRepository)
-	doi := conf.DOIBase + uuid[:6]
-
-	if libgin.IsRegisteredDOI(doi) {
-		resData.Success = false
-		resData.Level = "warning"
-		resData.Message = template.HTML(fmt.Sprintf(msgAlreadyRegistered, doi, doi))
-		renderResult(w, &resData)
-		return
-	}
-
-	regJob.Metadata.UUID = uuid
-
 	// exiting beyond this point should trigger an email notification
 	defer func() {
 		err := notifyAdmin(regJob, errors)
@@ -157,6 +160,23 @@ func startDOIRegistration(w http.ResponseWriter, r *http.Request, jobQueue chan 
 		// Render the result
 		renderResult(w, &resData)
 	}()
+
+	// generate random DOI (keep generating if it's already registered)
+	var doi string
+	for ntry := 0; doi == "" && libgin.IsRegisteredDOI(doi); ntry++ {
+		// limit to 5 attempts in case something goes wrong (a bug in the
+		// randomiser) or we somehow win the lottery and keep generating valid
+		// DOIs
+		if ntry == 5 {
+			resData.Success = false
+			resData.Level = "warning"
+			resData.Message = template.HTML(msgSubmitError)
+			renderResult(w, &resData)
+			return
+
+		}
+		doi = conf.DOIBase + randAlnum(6)
+	}
 
 	// NOTE: Delete?
 	_, err = conf.GIN.Session.RequestAccount(requser.Username)


### PR DESCRIPTION
DOIs are now randomly generated until a new (unregistered, unique) one is found.  Now we can register the same repository multiple times and the DOI doesn't rely on the name of the repository, which would cause issues when repositories were renamed or deleted.