### PR TITLE
Add full https://doi.org/<DOI> URL in references

### DIFF
--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -237,7 +237,7 @@ func GetCitation(md *libgin.RepositoryMetadata) string {
 		}
 		authors[idx] = fmt.Sprintf("%s %s", strings.TrimSpace(namesplit[0]), initials)
 	}
-	return fmt.Sprintf("%s (%d) %s. G-Node. doi:%s", strings.Join(authors, ", "), md.Year, md.Titles[0], md.Identifier.ID)
+	return fmt.Sprintf("%s (%d) %s. G-Node. https://doi.org/%s", strings.Join(authors, ", "), md.Year, md.Titles[0], md.Identifier.ID)
 }
 
 // GetReferences returns the references cited by a dataset.  If the references

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -297,9 +297,9 @@ func GetReferences(md *libgin.RepositoryMetadata) []libgin.Reference {
 			citation := referenceDescriptions[idx]
 			referenceDescriptions = append(referenceDescriptions[:idx], referenceDescriptions[idx+1:]...) // remove found element
 			_, citation = splitDescriptionType(citation)
-			// filter out the ID from the citation
-			idstr := fmt.Sprintf("(%s)", ref.ID)
-			citation = strings.Replace(citation, idstr, "", -1)
+			// filter out the DOI URL from the citation
+			urlstr := fmt.Sprintf("(%s)", ref.GetURL())
+			citation = strings.Replace(citation, urlstr, "", -1)
 			ref.Citation = citation
 		}
 		refs = append(refs, *ref)

--- a/templates/info.go
+++ b/templates/info.go
@@ -36,7 +36,7 @@ const DOIInfo = `
 	<h3>References</h3>
 	<ul class="doi itemlist">
 		{{range $index, $ref := $refs}}
-			<li itemprop="citation" itemscope itemtype="http://schema.org/CreativeWork"><span itemprop="name">{{$ref.Name}} {{$ref.Citation}}</span>{{if $ref.ID}} <a href="{{$ref.GetURL}}" itemprop="url"><span itemprop="identifier">{{$ref.ID}}</span></a>{{end}}</li>
+			<li itemprop="citation" itemscope itemtype="http://schema.org/CreativeWork"><span itemprop="name">{{$ref.Name}} {{$ref.Citation}}</span>{{if $ref.ID}} <a href="{{$ref.GetURL}}" itemprop="url"><span itemprop="identifier">{{$ref.GetURL}}</span></a>{{end}}</li>
 		{{end}}
 	</ul>
 {{end}}


### PR DESCRIPTION
Instead of just DOI:<DOI> with link.
Assumes the URL exists in the reference description in the XML in parentheses, which is how we modified the current references to be.

Counterpart to g-node/libgin#22.