### PR TITLE
Links to older and newer versions of the same base dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ _testmain.go
 doienv
 config/emails
 build
+
+coverage
+coverage.html

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ $(BUILDLOC)/$(APP): $(SOURCES)
 test: coverage
 
 coverage: $(SOURCES)
-	go test -coverpkg=./... -coverprofile=coverage ./...
+	go test -race -coverpkg=./... -coverprofile=coverage ./...
 
 showcoverage: coverage
 	go tool cover -html=coverage

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ LDFLAGS = -ldflags="-X main.appversion=$(VERNUM) -X main.build=$(BUILDNUM) -X ma
 
 SOURCES = $(shell find . -type f -iname "*.go") version go.mod go.sum
 
-.PHONY: $(APP) install clean uninstall test coverage showcoverage
+.PHONY: $(APP) install clean uninstall test
 
 $(APP): $(BUILDLOC)/$(APP)
 
@@ -42,5 +42,5 @@ test: coverage
 coverage: $(SOURCES)
 	go test -race -coverpkg=./... -coverprofile=coverage ./...
 
-showcoverage: coverage
-	go tool cover -html=coverage
+coverage.html: coverage
+	go tool cover -html=coverage -o coverage.html

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -304,9 +304,11 @@ func FormatReferences(md *libgin.RepositoryMetadata) []libgin.Reference {
 	// map IDs to new references for easier construction from the two sources
 	// but also use the slice to maintain order
 	for _, relid := range md.RelatedIdentifiers {
-		if relid.RelationType == "IsVariantFormOf" || relid.RelationType == "IsIdenticalTo" {
+		if relid.RelationType == "IsVariantFormOf" || relid.RelationType == "IsIdenticalTo" ||
+			relid.RelationType == "IsNewVersionOf" || relid.RelationType == "IsOldVersionOf" {
 			// IsVariantFormOf is used for the URLs.
 			// IsIdenticalTo is used for the old DOI URLs.
+			// Is{New,Old}Version of is used for {new,old} versions of the same dataset.
 			// Here we assume that any other type is a citation
 			continue
 		}

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -428,10 +428,30 @@ func prepareTemplates(templateNames ...string) (*template.Template, error) {
 	return tmpl, nil
 }
 
-func NewVersionNotice(md *libgin.RepositoryMetadata) string {
+func NewVersionNotice(md *libgin.RepositoryMetadata) template.HTML {
+	for _, relid := range md.RelatedIdentifiers {
+		if relid.RelationType == "IsOldVersionOf" {
+			noticeContainer := `
+<div class="ui warning message">
+	<div class="header">New dataset version</div>
+	<p>%s<p>
+</div>`
+			url := fmt.Sprintf("https://doi.org/%s", relid.Identifier)
+			text := fmt.Sprintf("A newer version of this dataset is available at <a href=%s>%s</a>", url, url)
+			return template.HTML(fmt.Sprintf(noticeContainer, text))
+		}
+	}
 	return ""
 }
 
-func OldVersionLink(md *libgin.RepositoryMetadata) string {
+func OldVersionLink(md *libgin.RepositoryMetadata) template.HTML {
+	for _, relid := range md.RelatedIdentifiers {
+		if relid.RelationType == "IsNewVersionOf" {
+			url := fmt.Sprintf("https://doi.org/%s", relid.Identifier)
+			header := "<h3>Versions</h3>"
+			text := fmt.Sprintf("An older version of this dataset is available at <a href=%s>%s</a>", url, url)
+			return template.HTML(header + "\n" + text)
+		}
+	}
 	return ""
 }

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -47,6 +47,8 @@ var tmplfuncs = template.FuncMap{
 	"FormatIssuedDate": FormatIssuedDate,
 	"KeywordPath":      KeywordPath,
 	"FormatAuthorList": FormatAuthorList,
+	"NewVersionNotice": NewVersionNotice,
+	"OldVersionLink":   OldVersionLink,
 }
 
 func readBody(r *http.Request) (*string, error) {
@@ -424,4 +426,12 @@ func prepareTemplates(templateNames ...string) (*template.Template, error) {
 		}
 	}
 	return tmpl, nil
+}
+
+func NewVersionNotice(md *libgin.RepositoryMetadata) string {
+	return ""
+}
+
+func OldVersionLink(md *libgin.RepositoryMetadata) string {
+	return ""
 }

--- a/templates/info.go
+++ b/templates/info.go
@@ -20,6 +20,8 @@ const DOIInfo = `
 </div>
 <hr>
 
+{{NewVersionNotice .}}
+
 {{if .Descriptions}}
 	<h3>Description</h3>
 	<p itemprop="description">{{with index .Descriptions 0}}{{.Content}}{{end}}</p>
@@ -50,4 +52,6 @@ const DOIInfo = `
 		{{end}}
 	</ul>
 {{end}}
+
+{{OldVersionLink .}}
 `


### PR DESCRIPTION
When a repository is registered multiple times, we indicate the relation between older and newer versions using related identifiers with types "IsOldVersionOf" and "IsNewVersionOf" appropriately.  We now use that information to add a notice to the landing page of an older dataset that links to the newer one.  On the landing page of the newer dataset, a less visible link to the older version is added as well.

Closes #57.

Example of an old version
![image](https://user-images.githubusercontent.com/2369197/96286486-bc3ae780-0fe0-11eb-9bb3-b417f7549eb9.png)

Example of a new version
![image](https://user-images.githubusercontent.com/2369197/96286560-d8d71f80-0fe0-11eb-8144-1b0c619951d2.png)
