### PR TITLE
Add notice about content licensed under different terms

### DIFF
--- a/templates/reqpage.go
+++ b/templates/reqpage.go
@@ -76,7 +76,7 @@ const RequestPage = `<!DOCTYPE html>
 								<li>Did you upload all data?</li>
 								<li>Does your repository contain a comprehensive description of the data (preferably in the README.md file)?</li>
 								<li>Does your repository contain a LICENSE file with a license matching the one indicated in datacite.yml?</li>
-								<li>Does your repository contain code or content licensed under different terms? You can include a separate LICENSE file for parts of the repository and describe its application in the README.</li>
+								<li>Does your repository contain code or content licensed under different terms? Please include a separate LICENSE file for parts of the repository and describe its application in the README.</li>
 							</ul>
 							<p><b>Please be aware that the entire repository will be published.</b></p>
 							<p><b>Please make sure it does not contain any private files, SSH keys, address books, password collections, or similar sensitive, private data.</b></p>

--- a/templates/reqpage.go
+++ b/templates/reqpage.go
@@ -76,6 +76,7 @@ const RequestPage = `<!DOCTYPE html>
 								<li>Did you upload all data?</li>
 								<li>Does your repository contain a comprehensive description of the data (preferably in the README.md file)?</li>
 								<li>Does your repository contain a LICENSE file with a license matching the one indicated in datacite.yml?</li>
+								<li>Does your repository contain code or content licensed under different terms? You can include a separate LICENSE file for parts of the repository and describe its application in the README.</li>
 							</ul>
 							<p><b>Please be aware that the entire repository will be published.</b></p>
 							<p><b>Please make sure it does not contain any private files, SSH keys, address books, password collections, or similar sensitive, private data.</b></p>


### PR DESCRIPTION
On the request preparation page, include a warning about content licensed under different terms, specifically mentioning code.

It's not the most visible warning, but it might help.  It's not a very common case either, so I think it wouldn't be appropriate to add a bigger notice.