### PR TITLE
App freeze fix, zip changes and assets mapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY ./assets /assets
 COPY --from=binbuilder /gindoid/build/gindoid /
 VOLUME ["/doidata"]
 VOLUME ["/config"]
+VOLUME ["/doiprep"]
 
 ENTRYPOINT /gindoid start
 EXPOSE 10443

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,8 @@ VOLUME ["/doidata"]
 VOLUME ["/config"]
 VOLUME ["/doiprep"]
 
-ENTRYPOINT /gindoid start
 EXPOSE 10443
+# ENTRYPOINT /gindoid start
+ADD docker_startup.sh .
+RUN chmod +x ./docker_startup.sh
+ENTRYPOINT ["./docker_startup.sh"]

--- a/cmd/gindoid/config.go
+++ b/cmd/gindoid/config.go
@@ -45,6 +45,8 @@ type Configuration struct {
 	// Settings related to the storage location for published data and landing
 	// pages
 	Storage struct {
+		// Directory for cloning and zip creation
+		PreparationDirectory string
 		// Root storage location
 		TargetDirectory string
 		// URL where the published data is served from (used for email
@@ -75,6 +77,7 @@ func loadconfig() (*Configuration, error) {
 	cfg.Email.From = libgin.ReadConf("mailfrom")
 	cfg.Email.RecipientsFile = libgin.ReadConf("mailtofile")
 
+	cfg.Storage.PreparationDirectory = libgin.ReadConf("preparation")
 	cfg.Storage.TargetDirectory = libgin.ReadConf("target")
 	cfg.Storage.StoreURL = libgin.ReadConf("storeurl")
 	cfg.Storage.XMLURL = libgin.ReadConf("xmlurl")

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -133,7 +133,7 @@ func cloneAndZip(repopath string, jobname string, targetpath string, conf *Confi
 	// use DOI with / replacement for zip filename
 	zipbasename := strings.ReplaceAll(jobname, "/", "_") + ".zip"
 	zipfilename := filepath.Join(targetpath, zipbasename)
-	zipsize, err := zip(repodir, zipfilename)
+	zipsize, err := runzip(repodir, zipfilename)
 	if err != nil {
 		log.Print("Could not zip the data")
 		return "", -1, fmt.Errorf("Failed to create the zip file: %v", err)
@@ -142,9 +142,9 @@ func cloneAndZip(repopath string, jobname string, targetpath string, conf *Confi
 	return zipbasename, zipsize, nil
 }
 
-// zip a source directory into a file with the given filename.
-func zip(source, zipfilename string) (int64, error) {
-	fn := fmt.Sprintf("zip(%s, %s)", source, zipfilename) // keep original args for errmsg
+// runzip zips a source directory into a file with the given filename.
+func runzip(source, zipfilename string) (int64, error) {
+	fn := fmt.Sprintf("runzip(%s, %s)", source, zipfilename) // keep original args for errmsg
 	source, err := filepath.Abs(source)
 	if err != nil {
 		log.Printf("%s: Failed to get abs path for source directory in function '%s': %v", lpStorage, fn, err)

--- a/cmd/gindoid/dataset_test.go
+++ b/cmd/gindoid/dataset_test.go
@@ -118,8 +118,8 @@ func TestMakeZip(t *testing.T) {
 	}
 	// Files excluded from the zip file
 	excl := map[string]struct{}{
-		".git/excluded.md":     {},
-		"excluded/excluded.md": {},
+		".git/excluded.md":      {},
+		".excluded/excluded.md": {},
 	}
 
 	zipreader, err := zip.OpenReader(zipfilename)
@@ -132,7 +132,7 @@ func TestMakeZip(t *testing.T) {
 	for _, file := range zipreader.File {
 		if _, included := incl[file.Name]; !included {
 			if _, notExcluded := excl[file.Name]; notExcluded {
-				t.Fatalf("Unexpected file found: %s", file.Name)
+				t.Fatalf("Not excluded file found: %s", file.Name)
 			}
 		} else {
 			includedCounter = append(includedCounter, file.Name)

--- a/cmd/gindoid/dataset_test.go
+++ b/cmd/gindoid/dataset_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"archive/zip"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMakeZip(t *testing.T) {
+	targetpath, err := ioutil.TempDir("", "test_libgin_makezip")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(targetpath)
+
+	ziproot := filepath.Join(targetpath, "mkzip")
+
+	// Create test directory tree
+	handletestdir := func() error {
+		// Create directories
+		inclpath := filepath.Join(ziproot, "included")
+		exclpath := filepath.Join(ziproot, ".excluded")
+		gitpath := filepath.Join(ziproot, ".git")
+		if err = os.MkdirAll(inclpath, 0755); err != nil {
+			return fmt.Errorf("Error creating directory %s: %v", inclpath, err)
+		}
+		if err = os.MkdirAll(exclpath, 0755); err != nil {
+			return fmt.Errorf("Error creating directory %s: %v", exclpath, err)
+		}
+		if err = os.MkdirAll(gitpath, 0755); err != nil {
+			return fmt.Errorf("Error creating directory %s: %v", gitpath, err)
+		}
+
+		mkfile := func(currfile string) error {
+			fp, err := os.Create(currfile)
+			if err != nil {
+				return fmt.Errorf("Error creating file %s: %v", currfile, err)
+			}
+			fp.Close()
+			return nil
+		}
+		// Create files
+		if err = mkfile(filepath.Join(ziproot, "included.md")); err != nil {
+			return err
+		}
+		if err = mkfile(filepath.Join(gitpath, "excluded.md")); err != nil {
+			return err
+		}
+		if err = mkfile(filepath.Join(inclpath, "included.md")); err != nil {
+			return err
+		}
+		if err = mkfile(filepath.Join(inclpath, "not_excluded.md")); err != nil {
+			return err
+		}
+		if err = mkfile(filepath.Join(exclpath, "excluded.md")); err != nil {
+			return err
+		}
+
+		return nil
+	}
+	if err = handletestdir(); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	zipbasename := "test_makezip.zip"
+	zipfilename := filepath.Join(targetpath, zipbasename)
+
+	// Checks that files in directories ".git" and ".excluded" are excluded and
+	// file "not_excluded" is still added.
+	exclude := []string{".git", ".excluded", "not_excluded.md"}
+
+	handlezip := func() error {
+		fn := fmt.Sprintf("zip(%s, %s)", ziproot, zipfilename)
+		source, err := filepath.Abs(ziproot)
+		if err != nil {
+			return fmt.Errorf("Failed to get abs path for source directory in function '%s': %v", fn, err)
+		}
+
+		zipfilename, err = filepath.Abs(zipfilename)
+		if err != nil {
+			return fmt.Errorf("Failed to get abs path for target zip file in function '%s': %v", fn, err)
+		}
+
+		zipfp, err := os.Create(zipfilename)
+		if err != nil {
+			return fmt.Errorf("Failed to create zip file for writing in function '%s': %v", fn, err)
+		}
+		defer zipfp.Close()
+
+		origdir, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("Failed to get working directory in function '%s': %v", fn, err)
+		}
+		defer os.Chdir(origdir)
+
+		if err := os.Chdir(source); err != nil {
+			return fmt.Errorf("Failed to change to source directory to make zip file in function '%s': %v", fn, err)
+		}
+
+		if err := MakeZip(zipfp, exclude, "."); err != nil {
+			return fmt.Errorf("Failed to change to source directory to make zip file in function '%s': %v", fn, err)
+		}
+		return nil
+	}
+
+	if err = handlezip(); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	// Files included in the zip file
+	incl := map[string]struct{}{
+		"included/included.md":     {},
+		"included/not_excluded.md": {},
+		"included.md":              {},
+	}
+	// Files excluded from the zip file
+	excl := map[string]struct{}{
+		".git/excluded.md":     {},
+		"excluded/excluded.md": {},
+	}
+
+	zipreader, err := zip.OpenReader(zipfilename)
+	if err != nil {
+		t.Fatalf("Error opening zip file: %v", err)
+	}
+	defer zipreader.Close()
+
+	var includedCounter []string
+	for _, file := range zipreader.File {
+		if _, included := incl[file.Name]; !included {
+			if _, notExcluded := excl[file.Name]; notExcluded {
+				t.Fatalf("Unexpected file found: %s", file.Name)
+			}
+		} else {
+			includedCounter = append(includedCounter, file.Name)
+		}
+	}
+	if len(includedCounter) != len(incl) {
+		t.Fatalf("Zip does not include correct number of elements: %v/%v\n%v", len(includedCounter), len(incl), includedCounter)
+	}
+}

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -117,23 +117,37 @@ func ReferenceID(ref libgin.Reference) string {
 	return EscXML(idparts[1])
 }
 
-// FunderName splits the funder name from a funding string of the form <FunderName>, <AwardNumber>.
-// This is a utility function for the doi.xml template.
+// FunderName splits the funder name from a funding string of the form <FunderName>; <AwardNumber>.
+// This is a utility function for the doi.xml template. Split character is semi-colon,
+// but for backwards compatibility reasons, comma is supported as a fallback split character
+// if no semi-colon is provided.
 func FunderName(fundref string) string {
-	fuparts := strings.SplitN(fundref, ",", 2)
+	splitchar := ";"
+	if !strings.Contains(fundref, splitchar) {
+		splitchar = ","
+	}
+
+	fuparts := strings.SplitN(fundref, splitchar, 2)
 	if len(fuparts) != 2 {
-		// No comma, return as is
+		// No splitchar, return as is
 		return EscXML(fundref)
 	}
 	return EscXML(strings.TrimSpace(fuparts[0]))
 }
 
-// AwardNumber splits the award number from a funding string of the form <FunderName>, <AwardNumber>.
-// This is a utility function for the doi.xml template.
+// AwardNumber splits the award number from a funding string of the form <FunderName>; <AwardNumber>.
+// This is a utility function for the doi.xml template. Split character is semi-colon,
+// but for backwards compatibility reasons, comma is supported as a fallback split character
+// if no semi-colon is provided.
 func AwardNumber(fundref string) string {
-	fuparts := strings.SplitN(fundref, ",", 2)
+	splitchar := ";"
+	if !strings.Contains(fundref, splitchar) {
+		splitchar = ","
+	}
+
+	fuparts := strings.SplitN(fundref, splitchar, 2)
 	if len(fuparts) != 2 {
-		// No comma, return empty
+		// No splitchar, return empty
 		return ""
 	}
 	return EscXML(strings.TrimSpace(fuparts[1]))

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestAwardNumber checks proper AwardNumber split and return in util.AwardNumber.
+func TestAwardNumber(t *testing.T) {
+	subname := "funder name"
+	subnum := "award; number"
+
+	// Test normal split on semi-colon
+	instr := fmt.Sprintf("%s; %s", subname, subnum)
+	outstr := AwardNumber(instr)
+	if outstr != subnum {
+		t.Fatalf("AwardNumber 'normal' parse error: (in) '%s' (out) '%s' (expect) '%s'", instr, outstr, subnum)
+	}
+
+	// Test fallback comma split on missing semi-colon
+	subnum = "award, number"
+	instr = fmt.Sprintf("%s, %s", subname, subnum)
+	outstr = AwardNumber(instr)
+	if outstr != subnum {
+		t.Fatalf("AwardNumber 'fallback' parse error: (in) '%s' (out) '%s' (expect) '%s'", instr, outstr, subnum)
+	}
+
+	// Test empty non split return
+	subnum = "award number"
+	instr = fmt.Sprintf("%s%s", subname, subnum)
+	outstr = AwardNumber(instr)
+	if outstr != "" {
+		t.Fatalf("AwardNumber 'no-split' parse error: (in) '%s' (out) '%s' (expect) ''", instr, outstr)
+	}
+
+	// Test no issue on empty string
+	outstr = AwardNumber("")
+
+	// Test proper split on comma with semi-colon and surrounding whitespaces
+	subnumissue := " award, num "
+	subnumclean := "award, num"
+	instr = fmt.Sprintf("%s;%s", subname, subnumissue)
+	outstr = AwardNumber(instr)
+	if outstr != subnumclean {
+		t.Fatalf("AwardNumber 'issues' parse error: (in) '%s' (out) '%s' (expect) '%s'", instr, outstr, subnumclean)
+	}
+}
+
+// TestFunderName checks proper FunderName split and return in util.FunderName.
+func TestFunderName(t *testing.T) {
+	subname := "funder name"
+	subnum := "award number"
+
+	// Test normal split on semi-colon
+	instr := fmt.Sprintf("%s; %s", subname, subnum)
+	outstr := FunderName(instr)
+	if outstr != subname {
+		t.Fatalf("Fundername 'normal' parse error: (in) '%s' (out) '%s' (expect) '%s'", instr, outstr, subname)
+	}
+
+	// Test fallback comma split on missing semi-colon
+	instr = fmt.Sprintf("%s, %s", subname, subnum)
+	outstr = FunderName(instr)
+	if outstr != subname {
+		t.Fatalf("Fundername 'fallback' parse error: (in) '%s' (out) '%s' (expect) '%s'", instr, outstr, subname)
+	}
+
+	// Test non split return
+	instr = fmt.Sprintf("%s%s", subname, subnum)
+	outstr = FunderName(instr)
+	if outstr != instr {
+		t.Fatalf("Fundername 'no-split' parse error: (in) '%s' (out) '%s' (expect) '%s'", instr, outstr, instr)
+	}
+
+	// Test no issue on empty string
+	outstr = FunderName("")
+
+	// Test proper split on comma with semi-colon and surrounding whitespaces
+	subnameissue := " funder, name "
+	subnameclean := "funder, name"
+	instr = fmt.Sprintf("%s;%s", subnameissue, subnum)
+	outstr = FunderName(instr)
+	if outstr != subnameclean {
+		t.Fatalf("Fundername 'issues' parse error: (in) '%s' (out) '%s' (expect) '%s'", instr, outstr, subnameclean)
+	}
+}

--- a/docker_startup.sh
+++ b/docker_startup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+# Make html style assets available to the DOI hosting service.
+# When the '/doidata' volume is mounted from the host on startup
+# of the docker container, any data in this directory is no longer
+# available.
+# This script copies all required assets to the '/doidata' volume
+# after startup, making the assets available to the DOI hosting service.
+# If required also creates the '/doidata/assets' directory.
+echo "Preparing 'assets' directory; overwriting any previous 'assets' changes."
+mkdir -p /doidata/assets
+cp -vr /assets/* /doidata/assets
+
+# Start DOI registration server
+echo "Starting DOI registration server"
+/gindoid start

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.6.2 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
-	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	gopkg.in/ini.v1 v1.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,6 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
-golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
This PR introduces the following major and minor changes:

## Changes in the DOI registration procedure
- the DOI preparation server now clones the request GIN repository to a directory different from the hosting directory. This directory can be defined via the `doienv` environmental variables config file. The specific variable name is `preparation`.
- the zip functionality now actively excludes the `.git` folder from the zip file. The `derepoCloneDir` function has been removed from the registration procedure. This leaves the cloned repository intact in the `preparation` directory on the host machine and can be used for manual registration steps e.g. upload of annexed data to the DOI fork of the repository.
- the `Dockerfile` also supports the newly introduced `preparation` folder.

## Removing the application freeze on git annex uninit
The removal of the `derepoCloneDir` resolves the issue of very large datasets freezing the registration process on the `git annex uninit` step. For details see issue #78. It is still unclear why the application freeze had happened, but tests with repositories that consistently froze the service in multiple test runs now succeed without any issues.

## Providing the '/assets' content to a docker host
The DOI registration service and the static DOI hosting service both use the same 'assets'. Until now the assets from `/assets` had to be manually copied to the DOI hosting service when changes to the assets were made after deploying a new version of the DOI registration service.
The PR introduces a `docker_startup.sh` shell script as a new entrypoint for Docker deployment. This script copies the content of the 'assets' folder to the `/doidata` volume after the docker container has been started. This ensures, that the host, that is using the `/doidata` volume to statically provide registered DOI datasets, now automatically has access to the same 'assets' as the DOI registration service. Closes #85.

## Minor changes
- the local `zip` function has been renamed to `runzip` to avoid any potential name clashes with the standard library package `archive/zip`.
- the `MakeZip` function is copied from the 'G-Node/libgin' library, since it is only used by gin-doi and none of the other gin libraries; it is also unlikely that it will be used by another gin library. The code added also includes a basic test.
- updated funding information handling: FunderName and AwardNumber now use ";" as default splitstring and "," as fallback splitstring for backwards compatibility. Closes #84.
