### PR TITLE
License checks

### DIFF
--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -386,18 +386,11 @@ func readAndValidate(conf *Configuration, repository string) (*libgin.Repository
 		return nil, err
 	}
 
-	licenseText, err := readFileAtURL(repoFileURL(conf, repository, "LICENSE"))
+	// fail registration on missing LICENSE file
+	_, err = readFileAtURL(repoFileURL(conf, repository, "LICENSE"))
 	if err != nil {
 		log.Printf("Failed to fetch LICENSE: %s", err.Error())
 		return nil, fmt.Errorf(msgNoLicenseFile)
-	}
-
-	expectedTextURL := repoFileURL(conf, "G-Node/Info", fmt.Sprintf("licenses/%s", repoMetadata.License.Name))
-	if !checkLicenseMatch(expectedTextURL, string(licenseText)) {
-		// License file doesn't match specified license
-		errmsg := fmt.Sprintf("License file does not match specified license: %q", repoMetadata.License.Name)
-		log.Print(errmsg)
-		return nil, fmt.Errorf(msgLicenseMismatch)
 	}
 
 	// fail registration if unsupported values have been used

--- a/cmd/gindoid/licenses.go
+++ b/cmd/gindoid/licenses.go
@@ -1,0 +1,104 @@
+package main
+
+// defaultLicensesJSON are the most commonly used licenses for DOI registrations.
+// The content is used to check the licenses in new DOI registrations and warn
+// about discrepancies between used license URL, name and license content.
+const defaultLicensesJSON = `[
+{
+	"URL":   "http://www.apache.org/licenses/LICENSE-2.0",
+	"Name":  "Apache License",
+	"Alias": [
+	"Apache License",
+	"Apache License 2.0"
+	]
+},
+{
+	"URL":   "https://opensource.org/licenses/MIT",
+	"Name":  "The MIT License",
+	"Alias": [
+	"The MIT License",
+	"MIT License"
+	]
+},
+{
+	"URL":   "https://opensource.org/licenses/BSD-3-Clause",
+	"Name":  "The 3-Clause BSD License",
+	"Alias": [
+	"The 3-Clause BSD License",
+	"BSD-3-Clause"
+	]
+},
+{
+	"URL":   "https://www.gnu.org/licenses/gpl-3.0.en.html",
+	"Name":  "GNU General Public License v3.0",
+	"Alias": [
+	"GNU General Public License v3.0",
+	"GNU General Public License"
+	]
+},
+{
+	"URL":   "https://creativecommons.org/publicdomain/zero/1.0/",
+	"Name":  "CC0 1.0 Universal",
+	"Alias": [
+	"CC0 1.0 Universal",
+	"CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+	"Creative Commons CC0 1.0 Public Domain Dedication",
+	"CC0"
+	]
+},
+{
+	"URL":   "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+	"Name":  "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License",
+	"Alias": [
+	"Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License",
+	"Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)",
+	"Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)",
+	"Attribution-NonCommercial-ShareAlike 4.0 International",
+	"CC-BY-NC-SA 4.0",
+	"CC-BY-NC-SA"
+	]
+},
+{
+	"URL":   "https://creativecommons.org/licenses/by-nc-nd/4.0",
+	"Name":  "Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License",
+	"Alias": [
+	"Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License",
+	"Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)",
+	"CC-BY-NC-ND 4.0",
+	"CC-BY-NC-ND"
+	]
+},
+{
+	"URL":   "https://creativecommons.org/licenses/by-nc/4.0",
+	"Name":  "Creative Commons Attribution-NonCommercial 4.0 International Public License",
+	"Alias": [
+	"Creative Commons Attribution-NonCommercial 4.0 International Public License",
+	"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)",
+	"CC BY-NC 4.0",
+	"CC BY-NC"
+	]
+},
+{
+	"URL":   "https://creativecommons.org/licenses/by-sa/4.0",
+	"Name":  "Creative Commons Attribution-ShareAlike 4.0 International Public License",
+	"Alias": [
+	"Creative Commons Attribution-ShareAlike 4.0 International Public License",
+	"Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)",
+	"Creative Commons Attribution-ShareAlike 4.0",
+	"CC BY-SA 4.0",
+	"CC BY-SA"
+	]
+},
+{
+	"URL":   "https://creativecommons.org/licenses/by/4.0",
+	"Name":  "Creative Commons Attribution 4.0 International Public License",
+	"Alias": [
+	"Creative Commons Attribution 4.0 International Public License",
+	"Creative Commons Attribution 4.0 International License",
+	"Attribution 4.0 International (CC BY 4.0)",
+	"CC BY 4.0",
+	"CC BY"
+	]
+}
+]
+`

--- a/cmd/gindoid/licenses.go
+++ b/cmd/gindoid/licenses.go
@@ -25,6 +25,7 @@ const defaultLicensesJSON = `[
 	"Name":  "The 3-Clause BSD License",
 	"Alias": [
 	"The 3-Clause BSD License",
+	"BSD 3-Clause License",
 	"BSD-3-Clause"
 	]
 },
@@ -37,7 +38,7 @@ const defaultLicensesJSON = `[
 	]
 },
 {
-	"URL":   "https://creativecommons.org/publicdomain/zero/1.0/",
+	"URL":   "https://creativecommons.org/publicdomain/zero/1.0",
 	"Name":  "CC0 1.0 Universal",
 	"Alias": [
 	"CC0 1.0 Universal",
@@ -47,7 +48,7 @@ const defaultLicensesJSON = `[
 	]
 },
 {
-	"URL":   "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+	"URL":   "https://creativecommons.org/licenses/by-nc-sa/4.0",
 	"Name":  "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License",
 	"Alias": [
 	"Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License",

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -68,6 +68,21 @@ type DOILicense struct {
 	Alias []string
 }
 
+// licFromURL identifies a common license from a []DOILicense via a specified license URL.
+// Returns either the found or an empty DOILicense and a corresponding boolean 'ok' flag.
+func licFromURL(commonLicenses []DOILicense, licenseURL string) (DOILicense, bool) {
+	url := cleancompstr(licenseURL)
+	for _, lic := range commonLicenses {
+		// provided licenses URLs can be more verbose than the default license URL
+		if strings.Contains(url, strings.ToLower(lic.URL)) {
+			return lic, true
+		}
+	}
+
+	var emptyLicense DOILicense
+	return emptyLicense, false
+}
+
 // ReadCommonLicenses returns an array of common DOI licenses.
 // The common DOI licenses are read from a "doi-licenses.json"
 // file found besides the DOI environment variables file. This

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -239,22 +239,6 @@ func checkMissingValues(info *libgin.RepositoryYAML) []string {
 	return missing
 }
 
-// checkLicenseMatch returns true if the license text found in the file at the
-// URL matches the provided license text. If the file at the URL cannot be
-// read, it defaults to true.
-func checkLicenseMatch(expectedTextURL string, licenseText string) bool {
-	expectedLicenseText, err := readFileAtURL(expectedTextURL)
-	if err != nil {
-		// License isn't known or there was a problem reading the file in the
-		// repository.
-		// Return positive response since we can't validate automatically.
-		log.Printf("Can't validate License text. Unknown license name in datacite.yml: %q", expectedTextURL)
-		return true
-	}
-
-	return string(expectedLicenseText) == licenseText
-}
-
 func contains(list []string, value string) bool {
 	for _, valid := range list {
 		if strings.ToLower(valid) == strings.ToLower(value) {

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/G-Node/libgin/libgin"
@@ -62,6 +65,29 @@ type DOILicense struct {
 	URL   string
 	Name  string
 	Alias []string
+}
+
+// licenseFromFile opens a file from a provided filepath and
+// json unmarshals the file contents into a []DOILicense.
+// Returns an error or a valid []DOILicense.
+func licenseFromFile(filepath string) ([]DOILicense, error) {
+	fp, err := os.Open(filepath)
+	if err != nil {
+		return nil, err
+	}
+	defer fp.Close()
+
+	jdata, err := ioutil.ReadAll(fp)
+	if err != nil {
+		return nil, err
+	}
+
+	var licenses []DOILicense
+	if err = json.Unmarshal(jdata, &licenses); err != nil {
+		return nil, err
+	}
+
+	return licenses, nil
 }
 
 // checkMissingValues returns a list of messages for missing or invalid values.

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -83,6 +83,22 @@ func licFromURL(commonLicenses []DOILicense, licenseURL string) (DOILicense, boo
 	return emptyLicense, false
 }
 
+// licFromName identifies a common license from a []DOILicense via a specific license title.
+// Returns either the found or an empty DOILicense and a corresponding boolean 'ok' flag.
+func licFromName(commonLicenses []DOILicense, licenseName string) (DOILicense, bool) {
+	licname := cleancompstr(licenseName)
+	for _, lic := range commonLicenses {
+		for _, alias := range lic.Alias {
+			if licname == strings.ToLower(alias) {
+				return lic, true
+			}
+		}
+	}
+
+	var emptyLicense DOILicense
+	return emptyLicense, false
+}
+
 // ReadCommonLicenses returns an array of common DOI licenses.
 // The common DOI licenses are read from a "doi-licenses.json"
 // file found besides the DOI environment variables file. This

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -133,3 +133,12 @@ func validateDataCiteValues(info *libgin.RepositoryYAML) []string {
 
 	return invalid
 }
+
+// cleancompstr cleans up an input string.
+// Surrounding whitespaces are removed and
+// converted to lower case.
+func cleancompstr(cleanup string) string {
+	cleanup = strings.TrimSpace(cleanup)
+	cleanup = strings.ToLower(cleanup)
+	return cleanup
+}

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -56,6 +56,14 @@ func collectWarnings(job *RegistrationJob) (warnings []string) {
 	return
 }
 
+// DOILicense holds Name (official license title), URL (license online reference)
+// and Alias names for a license used for a DOI registration.
+type DOILicense struct {
+	URL   string
+	Name  string
+	Alias []string
+}
+
 // checkMissingValues returns a list of messages for missing or invalid values.
 // If all values are valid, the returned slice is empty.
 func checkMissingValues(info *libgin.RepositoryYAML) []string {

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -80,13 +80,13 @@ func licenseWarnings(yada *libgin.RepositoryYAML, repoLicenseURL string, warning
 	// check if the datacite license can be matched to a common license via URL
 	licenseURL, ok := licFromURL(commonLicenses, yada.License.URL)
 	if !ok {
-		warnings = append(warnings, fmt.Sprintf("License URL not common: '%s'", yada.License.URL))
+		warnings = append(warnings, fmt.Sprintf("License URL (datacite) not found: '%s'", yada.License.URL))
 	}
 
 	// check if the license can be matched to a common license via datacite license name
 	licenseName, ok := licFromName(commonLicenses, yada.License.Name)
 	if !ok {
-		warnings = append(warnings, fmt.Sprintf("License datacite name not common: '%s'", yada.License.Name))
+		warnings = append(warnings, fmt.Sprintf("License name (datacite) not found: '%s'", yada.License.Name))
 	}
 
 	// check if the license can be matched to a common license via the header line of the license file
@@ -95,13 +95,18 @@ func licenseWarnings(yada *libgin.RepositoryYAML, repoLicenseURL string, warning
 	if err != nil {
 		warnings = append(warnings, fmt.Sprintf("Could not access license file"))
 	} else {
-		fileHeader := strings.Split(strings.Replace(string(content), "\r\n", "\n", -1), "\n")
-		var ok bool
+		headstr := string(content)
+		fileHeader := strings.Split(strings.Replace(headstr, "\r\n", "\n", -1), "\n")
+		var ok bool // false if fileHeader 0 or licFromName returns !ok
 		if len(fileHeader) > 0 {
 			licenseHeader, ok = licFromName(commonLicenses, fileHeader[0])
 		}
 		if !ok {
-			warnings = append(warnings, fmt.Sprintf("License file content header not common: '%v'", fileHeader))
+			// Limit license file content in warning message
+			if len(headstr) > 20 {
+				headstr = fmt.Sprintf("%s...", headstr[0:20])
+			}
+			warnings = append(warnings, fmt.Sprintf("License file content header not found: '%s'", headstr))
 		}
 	}
 

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -86,6 +86,38 @@ func TestReadCommonLicenses(t *testing.T) {
 	}
 }
 
+func TestLicFromURL(t *testing.T) {
+	liclist := ReadCommonLicenses()
+
+	// test license URL not in common license list
+	licURL := "I AM NOT HERE"
+	_, ok := licFromURL(liclist, licURL)
+	if ok {
+		t.Fatalf("License URL '%s' should not have been found", licURL)
+	}
+
+	// test finding deviating character case license URL
+	licName := "Creative Commons Attribution 4.0 International Public License"
+	licURL = " https://creativecommons.org/licenses/BY/4.0 "
+	lic, ok := licFromURL(liclist, licURL)
+	if !ok {
+		t.Fatalf("Error finding case insensitive URL: '%s'", licURL)
+	}
+	if lic.Name != licName {
+		t.Fatalf("Found invalid license: '%s' expected '%s'", lic.Name, licName)
+	}
+
+	// test finding long suffix version of license URL
+	licURL = "https://creativecommons.org/licenses/by/4.0/legalcode"
+	lic, ok = licFromURL(liclist, licURL)
+	if !ok {
+		t.Fatalf("Error finding suffix version URL: '%s'", licURL)
+	}
+	if lic.Name != licName {
+		t.Fatalf("Found invalid license: '%s' expected '%s'", lic.Name, licName)
+	}
+}
+
 func TestCleanupcompstr(t *testing.T) {
 	instr := "  aLLcasEs  "
 	expected := "allcases"

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -173,10 +173,10 @@ func TestLicenseWarnings(t *testing.T) {
 	if len(checkwarn) != 3 {
 		t.Fatalf("Unexpected warnings(%d): %v", len(checkwarn), checkwarn)
 	}
-	if !strings.Contains(checkwarn[0], "License URL not common: ''") {
+	if !strings.Contains(checkwarn[0], "License URL (datacite) not found: ''") {
 		t.Fatalf("Missing unkown license URL warning: %v", checkwarn)
 	}
-	if !strings.Contains(checkwarn[1], "License datacite name not common: ''") {
+	if !strings.Contains(checkwarn[1], "License name (datacite) not found: ''") {
 		t.Fatalf("Missing unknown license name warning: %v", checkwarn)
 	}
 	if !strings.Contains(checkwarn[2], "Could not access license file") {
@@ -190,7 +190,7 @@ func TestLicenseWarnings(t *testing.T) {
 	if len(checkwarn) != 3 {
 		t.Fatalf("Unexpected warnings(%d): %v", len(checkwarn), checkwarn)
 	}
-	if !strings.Contains(checkwarn[2], "License file content header not common: '") {
+	if !strings.Contains(checkwarn[2], "License file content header not found: '") {
 		t.Fatalf("Missing unknown license file header warning: %v", checkwarn)
 	}
 

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -50,6 +50,42 @@ func TestLicenseFromFile(t *testing.T) {
 	}
 }
 
+func TestReadCommonLicenses(t *testing.T) {
+	// check loading default licenses
+	liclist := ReadCommonLicenses()
+	// there should always be more than 2 default licenses
+	if len(liclist) < 2 {
+		t.Fatalf("Could not read default licenses")
+	}
+
+	// provide custom license file and check common licenses are loaded from there
+	tmpDir, err := ioutil.TempDir("", "test_gindoi_readCommonLicense")
+	if err != nil {
+		t.Fatalf("Error creating tmp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	licfile := filepath.Join(tmpDir, "doi-licenses.json")
+	licURL := "lic url"
+	content := fmt.Sprintf(`[{"URL": "%s", "Name":  "lic name", "Alias": ["alias name"]}]`, licURL)
+	err = writeTmpFile(licfile, content)
+	if err != nil {
+		t.Fatalf("Error creating json file: '%s'", err.Error())
+	}
+
+	err = os.Setenv("configdir", tmpDir)
+	if err != nil {
+		t.Fatalf("Error setting environment: %s", err.Error())
+	}
+	liclist = ReadCommonLicenses()
+	if len(liclist) != 1 {
+		t.Fatalf("Error reading custom license file")
+	}
+	if licURL != liclist[0].URL {
+		t.Fatalf("Unexpected license content: '%s'/'%s'", licURL, liclist[0].URL)
+	}
+}
+
 func TestCleanupcompstr(t *testing.T) {
 	instr := "  aLLcasEs  "
 	expected := "allcases"

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -9,6 +9,47 @@ import (
 	"testing"
 )
 
+func writeTmpFile(filename string, content string) error {
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	_, err = io.WriteString(file, content)
+	if err != nil {
+		return err
+	}
+	return file.Sync()
+}
+
+func TestLicenseFromFile(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "test_gindoi_licfromfile")
+	if err != nil {
+		t.Fatalf("Error creating tmp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	licfile := filepath.Join(tmpDir, "lic.json")
+	licURL := "lic url"
+	content := fmt.Sprintf(`[{"URL": "%s", "Name":  "lic name", "Alias": ["alias name"]}]`, licURL)
+	err = writeTmpFile(licfile, content)
+	if err != nil {
+		t.Fatalf("Error creating json file: '%s'", err.Error())
+	}
+
+	liclist, err := licenseFromFile(licfile)
+	if err != nil {
+		t.Fatalf("Could not load custom license file: '%s'", err.Error())
+	}
+	if len(liclist) != 1 {
+		t.Fatalf("Unexpected license list length: '%d'", len(liclist))
+	}
+	if licURL != liclist[0].URL {
+		t.Fatalf("Unexpected license content: '%s'/'%s'", licURL, liclist[0].URL)
+	}
+}
+
 func TestCleanupcompstr(t *testing.T) {
 	instr := "  aLLcasEs  "
 	expected := "allcases"

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -118,6 +118,38 @@ func TestLicFromURL(t *testing.T) {
 	}
 }
 
+func TestLicFromName(t *testing.T) {
+	liclist := ReadCommonLicenses()
+
+	// test license not found
+	licName := "I SHALL NOT BE FOUND"
+	_, ok := licFromName(liclist, licName)
+	if ok {
+		t.Fatalf("License name '%s' should not have been found", licName)
+	}
+
+	// test character case deviation name identification
+	licNameCorrect := "Creative Commons Attribution 4.0 International Public License"
+	licName = " creative commons attribution 4.0 International Public License "
+	lic, ok := licFromName(liclist, licName)
+	if !ok {
+		t.Fatalf("Error finding case deviant license name: '%s'", licName)
+	}
+	if lic.Name != licNameCorrect {
+		t.Fatalf("Found invalid license: '%s' expected '%s'", lic.Name, licNameCorrect)
+	}
+
+	// test identification by alias
+	licAlias := "  cc BY 4.0  "
+	lic, ok = licFromName(liclist, licAlias)
+	if !ok {
+		t.Fatalf("Error finding license by alias: '%s'", licAlias)
+	}
+	if lic.Name != licNameCorrect {
+		t.Fatalf("Found invalid license by alias: '%s' expected '%s'", lic.Name, licNameCorrect)
+	}
+}
+
 func TestCleanupcompstr(t *testing.T) {
 	instr := "  aLLcasEs  "
 	expected := "allcases"

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCleanupcompstr(t *testing.T) {
+	instr := "  aLLcasEs  "
+	expected := "allcases"
+	outstr := cleancompstr(instr)
+	if outstr != expected {
+		t.Fatalf("Error string cleanup: '%s' expected: '%s'", outstr, expected)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/G-Node/gin-cli v0.0.0-20200213155541-7b8a0596ebb3
-	github.com/G-Node/libgin v0.5.5
+	github.com/G-Node/libgin v0.5.6-0.20210301194327-b377a1283351
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/G-Node/gin-cli v0.0.0-20200213155541-7b8a0596ebb3 h1:4zukb20sUPdrQDBJ8TlWsQjFZK0TJgnwIhfiaY/+/Cc=
 github.com/G-Node/gin-cli v0.0.0-20200213155541-7b8a0596ebb3/go.mod h1:pnIO6Skp2YvaAdH6OyOmP4DhQCk5jz1zmwOola6JorU=
-github.com/G-Node/libgin v0.5.5 h1:Rb6jpk1FDEYIepTRFiCBZuddA/q+jZs0SCfL4gldFZY=
-github.com/G-Node/libgin v0.5.5/go.mod h1:FnAfNDz2IpuHYd119zKpPaCn0GKnd2i4goHeM5opunU=
+github.com/G-Node/libgin v0.5.6-0.20210301194327-b377a1283351 h1:WE1fFLS362yVT6kvM10vevVAC/4lNjBMNSU4XcX/SZc=
+github.com/G-Node/libgin v0.5.6-0.20210301194327-b377a1283351/go.mod h1:FnAfNDz2IpuHYd119zKpPaCn0GKnd2i4goHeM5opunU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
This PR adds code to check various aspects of provided license information when a DOI request is being processed. 

The license URL and license name provided via the datacite yaml file and the header line of the license file in the request repository are checked against a server internal common licenses struct array.
Warnings are issued, if any of the provided license URL, license name or header line cannot be identified as a common license and if URL, name and header do not appear to refer to one and the same license. This closes issue #79.

Since the full license text comparison and registration fail on minor license text differences is too strict and is therefore removed. This closes issue #87.

The PR also adds tests for all added functions.