### PR TITLE
Additional admin warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![Tests](https://github.com/g-node/gin-doi/workflows/run-tests/badge.svg?branch=master)](https://github.com/G-Node/gin-doi/actions)
+[![Coverage Status](https://coveralls.io/repos/github/G-Node/gin-doi/badge.svg?branch=master)](https://coveralls.io/github/G-Node/gin-doi?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/g-node/gin-doi)](https://goreportcard.com/report/github.com/g-node/gin-doi)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/g-node/gin-doi)](https://pkg.go.dev/github.com/G-Node/gin-doi)
+
 # GIN DOI
 
 GIN-DOI is the G-Node Infrastructure DOI service.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # GIN DOI
+
 GIN-DOI is the G-Node Infrastructure DOI service.
 The service can, at the request of a repository owner, copy a public repository, pack everything into an archive file, store it in a safe location, and provide a DOI (digital object identifier) with which the archive can be cited.
 
@@ -10,3 +11,13 @@ GIN-DOI fulfills the [DataCite](https://www.datacite.org/) standard which (accor
 * Establish easier access to research data on the Internet.
 * Increase acceptance of research data as legitimate, citable contributions to the scholarly record.
 * Support data archiving that will permit results to be verified and re-purposed for future study.
+
+## Dependencies
+
+gin-doi is dependent on the [G-Node/libgin](https://github.com/G-Node/libgin) and the [G-Node/gin-cli](https://github.com/G-Node/gin-cli).
+
+When building gin-doi from source and using a different version of `libgin` or `gin-cli` than specified in the `go.mod` file, use `go get` to fetch the latest `libgin` or `gin-cli` release or point to a specific commit in master.
+
+As an example:
+- `go get github.com/G-Node/libgin` to include the latest release
+- `go get github.com/G-Node/libgin@[commit hash]` for a specifc commit in the master branch of G-Node/libgin

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -393,7 +393,7 @@ func readAndValidate(conf *Configuration, repository string) (*libgin.Repository
 	_, err = readFileAtURL(repoFileURL(conf, repository, "LICENSE"))
 	if err != nil {
 		log.Printf("Failed to fetch LICENSE: %s", err.Error())
-		return nil, fmt.Errorf(msgNoLicenseFile)
+		return nil, fmt.Errorf("<p>%s</p>", msgNoLicenseFile)
 	}
 
 	// fail registration if unsupported values have been used

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -398,7 +398,7 @@ func readAndValidate(conf *Configuration, repository string) (*libgin.Repository
 
 	// fail registration if unsupported values have been used
 	if msgs := validateDataCiteValues(repoMetadata); len(msgs) > 0 {
-		err := fmt.Errorf("%s<i><p>%s</p></i>", msgInvalidDOI, strings.Join(msgs, "</p><p>"))
+		err := fmt.Errorf("%s<div align='left' style='padding-left: 50px;'><i><ul><li>%s</li></ul></i></div>", msgInvalidDOI, strings.Join(msgs, "</li><li>"))
 		return nil, err
 	}
 

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -332,8 +332,9 @@ func readRepoYAML(infoyml []byte) (*libgin.RepositoryYAML, error) {
 		return nil, fmt.Errorf("error while reading DOI info: %s", err.Error())
 	}
 	if missing := checkMissingValues(yamlInfo); len(missing) > 0 {
+		missing = deduplicateValues(missing)
 		log.Print("DOI file is missing entries")
-		return nil, fmt.Errorf(strings.Join(missing, " "))
+		return nil, fmt.Errorf(strings.Join(missing, "; "))
 	}
 	return yamlInfo, nil
 }
@@ -382,7 +383,9 @@ func readAndValidate(conf *Configuration, repository string) (*libgin.Repository
 	repoMetadata, err := readRepoYAML(dataciteText)
 	if err != nil {
 		log.Print("DOI file invalid")
-		err := fmt.Errorf("%s<p><i>%s</i></p>", msgInvalidDOI, err.Error())
+		// reformat error messages
+		msgs := strings.Split(err.Error(), "; ")
+		err := fmt.Errorf("%s<div align='left' style='padding-left: 50px;'><i><ul><li>%s</li></ul></i></div>", msgInvalidDOI, strings.Join(msgs, "</li><li>"))
 		return nil, err
 	}
 

--- a/cmd/gindoid/licenses.go
+++ b/cmd/gindoid/licenses.go
@@ -44,7 +44,8 @@ const defaultLicensesJSON = `[
 	"CC0 1.0 Universal",
 	"CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
 	"Creative Commons CC0 1.0 Public Domain Dedication",
-	"CC0"
+	"CC0",
+	"Creative Commons CC0 1.0 Universal"
 	]
 },
 {

--- a/cmd/gindoid/messages.go
+++ b/cmd/gindoid/messages.go
@@ -41,7 +41,7 @@ If you would like to make any changes to the dataset before it is published, or 
 	msgNoLicense        = "No valid license provided. Please specify a license URL and name and make sure it matches the license file in the repository."
 	msgNoLicenseFile    = `The LICENSE file is missing. The full text of the license is required to be in the repository when publishing. See the <a href="https://gin.g-node.org/G-Node/Info/wiki/Licensing">Licensing</a> help page for details and links to recommended data licenses.`
 	msgLicenseMismatch  = `The LICENSE file does not match the license specified in the metadata. See the <a href="https://gin.g-node.org/G-Node/Info/wiki/Licensing">Licensing</a> help page for links to full text for available licenses.`
-	msgInvalidReference = "One of the Reference entries is not valid. Please provide the full citation and type of the reference."
+	msgInvalidReference = "Not all Reference entries are valid. Please provide the full citation and type of the reference."
 	msgBadEncoding      = `There was an issue with the content of the DOI file (datacite.yml). This might mean that the encoding is wrong. Please see <a href="https://gin.g-node.org/G-Node/Info/wiki/DOIfile">the DOI guide</a> for detailed instructions or contact gin@g-node.org for assistance.`
 
 	msgSubmitError     = "An internal error occurred while we were processing your request.  The G-Node team has been notified of the problem and will attempt to repair it and process your request.  We may contact you for further information regarding your request.  Feel free to <a href=mailto:gin@g-node.org>contact us</a> if you would like to provide more information or ask about the status of your request."

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -66,6 +66,21 @@ func makeUUID(URI string) string {
 	return hex.EncodeToString(currMd5[:])
 }
 
+// deduplicateValues checks a string slice for duplicate
+// entries and returns a reduced string slice without any
+// duplicates.
+func deduplicateValues(dupvals []string) []string {
+	strmap := make(map[string]bool)
+	vals := []string{}
+	for _, val := range dupvals {
+		if _, exists := strmap[val]; !exists {
+			strmap[val] = true
+			vals = append(vals, val)
+		}
+	}
+	return vals
+}
+
 // EscXML runs a string through xml.EscapeText.
 // This is a utility function for the doi.xml template.
 func EscXML(txt string) string {

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -199,7 +199,9 @@ func AuthorBlock(authors []libgin.Creator) template.HTML {
 		var url, id, affiliationSup string
 		if author.Identifier != nil {
 			id = author.Identifier.ID
-			url = author.Identifier.SchemeURI + id
+			if author.Identifier.SchemeURI != "" {
+				url = author.Identifier.SchemeURI + id
+			}
 		}
 
 		// Author names are LastName, FirstName

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -2,8 +2,40 @@ package main
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 )
+
+func TestDeduplicateValues(t *testing.T) {
+	// check empty
+	check := []string{}
+	out := deduplicateValues(check)
+	if !reflect.DeepEqual(check, out) {
+		t.Fatalf("Slices (empty) are not equal: %v | %v", check, out)
+	}
+
+	// check nothing to deduplicate
+	check = []string{"a", "b", "c"}
+	out = deduplicateValues(check)
+	if !reflect.DeepEqual(check, out) {
+		t.Fatalf("Slices (no duplicates) are not equal: %v | %v", check, out)
+	}
+
+	// check deduplication
+	check = []string{"a", "b", "a", "c"}
+	expected := []string{"a", "b", "c"}
+	out = deduplicateValues(check)
+	if !reflect.DeepEqual(expected, out) {
+		t.Fatalf("Slices (duplicates) are not equal: %v | %v", expected, out)
+	}
+
+	// check no deduplication on different case
+	check = []string{"A", "b", "a", "B", "c"}
+	out = deduplicateValues(check)
+	if !reflect.DeepEqual(check, out) {
+		t.Fatalf("Slices (no case duplicates) are not equal: %v | %v", check, out)
+	}
+}
 
 // TestAwardNumber checks proper AwardNumber split and return in util.AwardNumber.
 func TestAwardNumber(t *testing.T) {

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -34,7 +34,7 @@ func TestAwardNumber(t *testing.T) {
 	}
 
 	// Test no issue on empty string
-	outstr = AwardNumber("")
+	_ = AwardNumber("")
 
 	// Test proper split on comma with semi-colon and surrounding whitespaces
 	subnumissue := " award, num "
@@ -73,7 +73,7 @@ func TestFunderName(t *testing.T) {
 	}
 
 	// Test no issue on empty string
-	outstr = FunderName("")
+	_ = FunderName("")
 
 	// Test proper split on comma with semi-colon and surrounding whitespaces
 	subnameissue := " funder, name "

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -160,7 +160,7 @@ func licenseWarnings(yada *libgin.RepositoryYAML, repoLicenseURL string, warning
 	var licenseHeader DOILicense
 	content, err := readFileAtURL(repoLicenseURL)
 	if err != nil {
-		warnings = append(warnings, fmt.Sprintf("Could not access license file"))
+		warnings = append(warnings, "Could not access license file")
 	} else {
 		headstr := string(content)
 		fileHeader := strings.Split(strings.Replace(headstr, "\r\n", "\n", -1), "\n")

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -70,12 +70,15 @@ func authorWarnings(yada *libgin.RepositoryYAML, warnings []string) []string {
 	var dupID = make(map[string]string)
 
 	for idx, auth := range yada.Authors {
+		if auth.ID == "" {
+			continue
+		}
 		lowerID := strings.ToLower(auth.ID)
 
 		// Warn when not able to identify ID type
-		if !strings.HasPrefix(lowerID, "orcid") && !strings.HasPrefix(lowerID, "researcherID") {
+		if !strings.HasPrefix(lowerID, "orcid") && !strings.HasPrefix(lowerID, "researcherid") {
 			if orcid := orcidRE.Find([]byte(auth.ID)); orcid != nil {
-				warnings = append(warnings, fmt.Sprintf("Author %d (%s) has ORCID like unspecified ID: %s", idx, auth.LastName, auth.ID))
+				warnings = append(warnings, fmt.Sprintf("Author %d (%s) has ORCID-like unspecified ID: %s", idx, auth.LastName, auth.ID))
 			} else {
 				warnings = append(warnings, fmt.Sprintf("Author %d (%s) has unknown ID: %s", idx, auth.LastName, auth.ID))
 			}
@@ -89,9 +92,10 @@ func authorWarnings(yada *libgin.RepositoryYAML, warnings []string) []string {
 
 		// Warn on dupliate ID entries
 		if authName, isduplicate := dupID[auth.ID]; isduplicate {
-			warnings = append(warnings, fmt.Sprintf("Authors %s and %s have the same ID: %s", authName, auth.LastName, auth.ID))
+			curr := fmt.Sprintf("%d (%s)", idx, auth.LastName)
+			warnings = append(warnings, fmt.Sprintf("Authors %s and %s have the same ID: %s", authName, curr, auth.ID))
 		} else {
-			dupID[auth.ID] = auth.LastName
+			dupID[auth.ID] = fmt.Sprintf("%d (%s)", idx, auth.LastName)
 		}
 	}
 

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -60,6 +60,11 @@ func collectWarnings(job *RegistrationJob) (warnings []string) {
 	// Check references
 	warnings = referenceWarnings(job.Metadata.YAMLData, warnings)
 
+	// Warn if resourceType is not 'Dataset'
+	if !strings.EqualFold(job.Metadata.YAMLData.ResourceType, "dataset") {
+		warnings = append(warnings, fmt.Sprintf("ResourceType is %q (expected Dataset)", job.Metadata.YAMLData.ResourceType))
+	}
+
 	return
 }
 

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -68,9 +68,20 @@ func referenceWarnings(yada *libgin.RepositoryYAML, warnings []string) []string 
 		if ref.Name != "" {
 			warnings = append(warnings, fmt.Sprintf("Reference %d uses old 'Name' field instead of 'Citation'", idx))
 		}
-		// Check and warn for reftypes different from "IsSupplementTo"
+
+		// Warn if reftypes are different from "IsSupplementTo"
 		if strings.ToLower(ref.RefType) != "issupplementto" {
 			warnings = append(warnings, fmt.Sprintf("Reference %d uses refType '%s'", idx, ref.RefType))
+		}
+
+		// Warn if a reference does not provide a relatedIdentifier
+		var relIDType string
+		refIDParts := strings.SplitN(ref.ID, ":", 2)
+		if len(refIDParts) == 2 {
+			relIDType = strings.TrimSpace(refIDParts[0])
+		}
+		if relIDType == "" {
+			warnings = append(warnings, fmt.Sprintf("Reference %d has no related ID type: '%s'; excluded from XML file", idx, ref.ID))
 		}
 	}
 	return warnings

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -61,8 +61,8 @@ func collectWarnings(job *RegistrationJob) (warnings []string) {
 
 // referenceWarnings checks datacite references for validity and
 // returns corresponding warnings if required.
-func referenceWarnings(ref *libgin.RepositoryYAML, warnings []string) []string {
-	for idx, ref := range ref.References {
+func referenceWarnings(yada *libgin.RepositoryYAML, warnings []string) []string {
+	for idx, ref := range yada.References {
 		// Check if a reference from the YAML file uses the old "Name" field instead of "Citation"
 		// This shouldn't be an issue, but it can cause formatting issues
 		if ref.Name != "" {

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -91,11 +91,11 @@ func authorWarnings(yada *libgin.RepositoryYAML, warnings []string) []string {
 		}
 
 		// Warn on dupliate ID entries
-		if authName, isduplicate := dupID[auth.ID]; isduplicate {
+		if authName, isduplicate := dupID[lowerID]; isduplicate {
 			curr := fmt.Sprintf("%d (%s)", idx, auth.LastName)
 			warnings = append(warnings, fmt.Sprintf("Authors %s and %s have the same ID: %s", authName, curr, auth.ID))
 		} else {
-			dupID[auth.ID] = fmt.Sprintf("%d (%s)", idx, auth.LastName)
+			dupID[lowerID] = fmt.Sprintf("%d (%s)", idx, auth.LastName)
 		}
 	}
 

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -306,11 +306,11 @@ func TestAuthorWarnings(t *testing.T) {
 	}
 
 	// Check warning on duplicate ORCID, researchID, unidentifyable ID
-	yada.Authors[0].ID = "orcid:0000-0000-0000-0000"
+	yada.Authors[0].ID = "orcid:0000-0000-0000-000x"
 	auth = yada.Authors
-	auth = append(auth, libgin.Author{ID: "researcherid:A-0000-0000"})
-	auth = append(auth, libgin.Author{ID: "orcid:0000-0000-0000-0000"})
-	auth = append(auth, libgin.Author{ID: "researcherid:A-0000-0000"})
+	auth = append(auth, libgin.Author{ID: "researcherid:a-0000-0000"})
+	auth = append(auth, libgin.Author{ID: "ORCID:0000-0000-0000-000X"})
+	auth = append(auth, libgin.Author{ID: "researcherID:A-0000-0000"})
 	yada.Authors = auth
 
 	checkwarn = authorWarnings(yada, warnings)

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -304,3 +304,40 @@ func TestValidateDataCiteValues(t *testing.T) {
 		t.Fatalf("Unexpected messages: %v", msgs)
 	}
 }
+
+func TestReferenceWarnings(t *testing.T) {
+	var warnings []string
+	// Check warnings on empty struct
+	yada := &libgin.RepositoryYAML{}
+
+	warn := referenceWarnings(yada, warnings)
+	if len(warn) != 0 {
+		t.Fatalf("Invalid number of messages(%d): %v", len(warn), warn)
+	}
+
+	// Check warning on "name" field used and warning on uncommon referenceType
+	var ref []libgin.Reference
+	ref = append(ref, libgin.Reference{Name: "used instead of citation", RefType: "IsDescribedBy"})
+	yada.References = ref
+
+	warn = referenceWarnings(yada, warnings)
+	if len(warn) != 2 {
+		t.Fatalf("Invalid number of messages(%d): %v", len(warn), warn)
+	}
+	if !strings.Contains(warn[0], "uses old 'Name' field instead of 'Citation'") {
+		t.Fatalf("Unexpected name field warning: %v", warn)
+	}
+	if !strings.Contains(warn[1], " uses refType 'IsDescribedBy'") {
+		t.Fatalf("Unexpected reference type warning: %v", warn)
+	}
+
+	// Check no warnings on valid reference
+	yada.References[0].Name = ""
+	yada.References[0].Citation = "validcitation"
+	yada.References[0].RefType = "IsSupplementTo"
+	yada.References[0].ID = "doi:10.12751/g-node.6953bb"
+	warn = referenceWarnings(yada, warnings)
+	if len(warn) != 0 {
+		t.Fatalf("Invalid number of messages(%d): %v", len(warn), warn)
+	}
+}

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -315,10 +315,32 @@ func TestReferenceWarnings(t *testing.T) {
 		t.Fatalf("Invalid number of messages(%d): %v", len(warn), warn)
 	}
 
-	// Check warning on "name" field used and warning on uncommon referenceType
+	// Check refIDType warning on empty ID
 	var ref []libgin.Reference
-	ref = append(ref, libgin.Reference{Name: "used instead of citation", RefType: "IsDescribedBy"})
+	ref = append(ref, libgin.Reference{RefType: "IsSupplementTo"})
 	yada.References = ref
+	warn = referenceWarnings(yada, warnings)
+	if len(warn) != 1 {
+		t.Fatalf("Invalid number of messages(%d): %v", len(warn), warn)
+	}
+	if !strings.Contains(warn[0], "has no related ID type:") {
+		t.Fatalf("Unexpected related ID type warning: %v", warn)
+	}
+
+	// Check refIDType warning on missing id type
+	yada.References[0].ID = "10.12751/g-node.6953bb"
+	warn = referenceWarnings(yada, warnings)
+	if len(warn) != 1 {
+		t.Fatalf("Invalid number of messages(%d): %v", len(warn), warn)
+	}
+	if !strings.Contains(warn[0], "has no related ID type:") {
+		t.Fatalf("Unexpected related ID type warning: %v", warn)
+	}
+
+	// Check warning on "name" field used and warning on uncommon referenceType
+	yada.References[0].ID = "doi:10.12751/g-node.6953bb"
+	yada.References[0].Name = "used instead of citation"
+	yada.References[0].RefType = "IsDescribedBy"
 
 	warn = referenceWarnings(yada, warnings)
 	if len(warn) != 2 {

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/G-Node/gin-doi
 
-go 1.13
+go 1.15
 
 require (
 	github.com/G-Node/gin-cli v0.0.0-20200213155541-7b8a0596ebb3
-	github.com/G-Node/libgin v0.5.6-0.20210301194327-b377a1283351
+	github.com/G-Node/libgin v0.5.6
 	github.com/dustin/go-humanize v1.0.0
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/G-Node/gin-cli v0.0.0-20200213155541-7b8a0596ebb3 h1:4zukb20sUPdrQDBJ8TlWsQjFZK0TJgnwIhfiaY/+/Cc=
 github.com/G-Node/gin-cli v0.0.0-20200213155541-7b8a0596ebb3/go.mod h1:pnIO6Skp2YvaAdH6OyOmP4DhQCk5jz1zmwOola6JorU=
-github.com/G-Node/libgin v0.5.6-0.20210301194327-b377a1283351 h1:WE1fFLS362yVT6kvM10vevVAC/4lNjBMNSU4XcX/SZc=
-github.com/G-Node/libgin v0.5.6-0.20210301194327-b377a1283351/go.mod h1:FnAfNDz2IpuHYd119zKpPaCn0GKnd2i4goHeM5opunU=
+github.com/G-Node/libgin v0.5.6 h1:g8N/0BhjKU5OLYDUHi3TImoxYymayh2KjjqHZBURbrM=
+github.com/G-Node/libgin v0.5.6/go.mod h1:FnAfNDz2IpuHYd119zKpPaCn0GKnd2i4goHeM5opunU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
This PR adds additional admin warnings when processing a DOI request. Some of these changes require [changes in the libgin library merged into master](https://github.com/G-Node/libgin/pull/29).
- admin warnings are added if a reftype other than `isSupplementTo` is used. Closes #73.
- a warning is added, if the ID type of a reference is not available. Changes in libgin now exclude such entries from the XML file and the warning points this out to the admin. Closes #76.
- warnings are added, if an authorID has duplicate entries, if the authorID type cannot be identified, or if the ID type is known, but the ID value is missing. Changes in libgin now exclude authorID entries that only provide the ID type but not the ID value. Closes #77.
- a warning is added, if the `resourceType` is not `Dataset`.
- when writing the HTML Author block, now there is no longer an authorID link created if no valid SchemeURI has been
identified to avoid in-site broken links.
- when registration errors occur, e.g. if the License file could not be found, when required fields are missing in the `datacite.yaml` file or when unsupported datacite values have been used, the collected error messages are now shown to the user as a formatted list. Closes #94.
- adds tests for added functionality.

The PR also updates the README file and adds CI badges and links.