### PR TITLE
Code cleanup

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,19 +30,17 @@ jobs:
         run: |
           go get golang.org/x/lint/golint
           golint ./...
-        # github actions discussion could make warnings like
-        # these visible eventually without failing the build.
-        # Check https://github.com/actions/toolkit/issues/399
-        continue-on-error: true
-      - name: Run errcheck
-        run: |
-          go get github.com/kisielk/errcheck
-          errcheck ./...
-        continue-on-error: true
       - name: Run staticcheck
         run: |
           go get honnef.co/go/tools/cmd/staticcheck
           staticcheck ./...
+        # github actions discussion could make warnings like
+        # these visible eventually without failing the build.
+        # Check https://github.com/actions/toolkit/issues/399
+      - name: Run errcheck
+        run: |
+          go get github.com/kisielk/errcheck
+          errcheck ./...
         continue-on-error: true
   tests:
     runs-on: [ubuntu-latest]

--- a/cmd/gindoid/config.go
+++ b/cmd/gindoid/config.go
@@ -69,7 +69,10 @@ func loadconfig() (*Configuration, error) {
 	if err != nil {
 		return nil, err
 	}
-	os.Setenv("GIN_CONFIG_DIR", confdir)
+	err = os.Setenv("GIN_CONFIG_DIR", confdir)
+	if err != nil {
+		log.Printf("Could not set GIN_CONFIG_DIR env: %q", err.Error())
+	}
 
 	cfg.DOIBase = libgin.ReadConf("doibase")
 
@@ -132,7 +135,10 @@ func loadconfig() (*Configuration, error) {
 	}
 	srvcfg.Git.HostKey = hostkeystr
 	log.Printf("Got hostkey with fingerprint:\n%s", fingerprint)
-	config.AddServerConf("gin", srvcfg)
+	err = config.AddServerConf("gin", srvcfg)
+	if err != nil {
+		log.Printf("Could not add gin-cli server config: %q", err.Error())
+	}
 	// Update known hosts file
 	err = git.WriteKnownHosts()
 	if err != nil {

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -116,7 +116,7 @@ func cloneAndZip(repopath string, jobname string, preppath string, targetpath st
 	log.Print("Start clone and zip")
 	// Clone at preppath (will create subdirectories '[doi-org-id]/[doi-jobname]/[reponame]')
 	if err := os.MkdirAll(preppath, 0777); err != nil {
-		errmsg := fmt.Sprintf("Failed to create temporary clone directory: %s", tmpdir)
+		errmsg := fmt.Sprintf("failed to create temporary clone directory: %s", tmpdir)
 		log.Print(errmsg)
 		return "", -1, fmt.Errorf(errmsg)
 	}
@@ -124,7 +124,7 @@ func cloneAndZip(repopath string, jobname string, preppath string, targetpath st
 	// Clone repository at the preparation path
 	if err := cloneRepo(repopath, preppath, conf); err != nil {
 		log.Print("Repository cloning failed")
-		return "", -1, fmt.Errorf("Failed to clone repository '%s': %v", repopath, err)
+		return "", -1, fmt.Errorf("failed to clone repository '%s': %v", repopath, err)
 	}
 
 	// Zip repository content to the target path
@@ -141,7 +141,7 @@ func cloneAndZip(repopath string, jobname string, preppath string, targetpath st
 	zipsize, err := runzip(repodir, zipfilename, exclude)
 	if err != nil {
 		log.Print("Could not zip the data")
-		return "", -1, fmt.Errorf("Failed to create the zip file: %v", err)
+		return "", -1, fmt.Errorf("failed to create the zip file: %v", err)
 	}
 	log.Printf("Archive size: %d", zipsize)
 	return zipbasename, zipsize, nil
@@ -314,7 +314,7 @@ func readFileAtURL(url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Request returned non-OK status: %s", resp.Status)
+		return nil, fmt.Errorf("request returned non-OK status: %s", resp.Status)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -503,7 +503,7 @@ func MakeZip(dest io.Writer, exclude []string, source ...string) error {
 	// check sources
 	for _, src := range source {
 		if _, err := os.Stat(src); err != nil {
-			return fmt.Errorf("Cannot access '%s': %s", src, err.Error())
+			return fmt.Errorf("cannot access '%s': %s", src, err.Error())
 		}
 	}
 
@@ -576,7 +576,7 @@ func MakeZip(dest io.Writer, exclude []string, source ...string) error {
 	for _, src := range source {
 		err := filepath.Walk(src, walker)
 		if err != nil {
-			return fmt.Errorf("Error adding %s to zip file: %s", src, err.Error())
+			return fmt.Errorf("error adding %s to zip file: %s", src, err.Error())
 		}
 	}
 	return nil

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -36,10 +36,13 @@ func createRegisteredDataset(job *RegistrationJob) error {
 	repopath := job.Metadata.SourceRepository
 	jobname := job.Metadata.Identifier.ID
 
-	prepDir(job)
+	preperrors := make([]string, 0, 7)
+	err := prepDir(job)
+	if err != nil {
+		preperrors = append(preperrors, fmt.Sprintf("Error preparing data directory : %q", err.Error()))
+	}
 
 	targetpath := filepath.Join(conf.Storage.TargetDirectory, jobname)
-	preperrors := make([]string, 0, 5)
 
 	ginurl, err := url.Parse(GetGINURL(conf))
 	if err != nil {

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -77,7 +77,11 @@ func createRegisteredDataset(job *RegistrationJob) error {
 	}
 
 	dynurl := GetGINURL(conf)
-	createLandingPage(job.Metadata, filepath.Join(conf.Storage.TargetDirectory, job.Metadata.Identifier.ID, "index.html"), dynurl)
+	err = createLandingPage(job.Metadata, filepath.Join(conf.Storage.TargetDirectory, job.Metadata.Identifier.ID, "index.html"), dynurl)
+	if err != nil {
+		// Landing page creation failed; append the error for reporting and continue with the XML prep
+		preperrors = append(preperrors, fmt.Sprintf("Failed to create the landing page: %q", err.Error()))
+	}
 
 	fp, err := os.Create(filepath.Join(targetpath, "doi.xml"))
 	if err != nil {

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -543,10 +543,10 @@ func MakeZip(dest io.Writer, exclude []string, source ...string) error {
 
 		// open files for zipping
 		f, err := os.Open(path)
-		defer f.Close()
 		if err != nil {
 			return err
 		}
+		defer f.Close()
 
 		// copy file data into zip writer
 		if _, err := io.Copy(w, f); err != nil {

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -300,28 +299,6 @@ func repoFileURL(conf *Configuration, repopath string, filename string) string {
 	fetchRepoPath := fmt.Sprintf("%s/raw/master/%s", repopath, filename)
 	u.Path = fetchRepoPath
 	return u.String()
-}
-
-// readFileAtURL returns the contents of a file at a given URL.
-func readFileAtURL(url string) ([]byte, error) {
-	client := &http.Client{}
-	log.Printf("Fetching file at %q", url)
-	req, _ := http.NewRequest(http.MethodGet, url, nil)
-	resp, err := client.Do(req)
-	if err != nil {
-		log.Printf("Request failed: %s", err.Error())
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("request returned non-OK status: %s", resp.Status)
-	}
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		log.Printf("Could not read file contents: %s", err.Error())
-		return nil, err
-	}
-	return body, nil
 }
 
 // readRepoYAML parses the DOI registration info and returns a filled DOIRegInfo struct.

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -84,7 +84,10 @@ func createRegisteredDataset(job *RegistrationJob) error {
 		log.Print("Could not create the metadata template")
 		// XML Creation failed; return with error
 		preperrors = append(preperrors, fmt.Sprintf("Failed to create the XML metadata template: %s", err))
-		notifyAdmin(job, preperrors, nil, false)
+		mailerr := notifyAdmin(job, preperrors, nil, false)
+		if mailerr != nil {
+			log.Printf("Failed to send notification email: %s", mailerr.Error())
+		}
 		return err
 	}
 	defer fp.Close()
@@ -93,7 +96,10 @@ func createRegisteredDataset(job *RegistrationJob) error {
 	if err != nil {
 		log.Print("Could not render the metadata file")
 		preperrors = append(preperrors, fmt.Sprintf("Failed to render the XML metadata: %s", err))
-		notifyAdmin(job, preperrors, nil, false)
+		mailerr := notifyAdmin(job, preperrors, nil, false)
+		if mailerr != nil {
+			log.Printf("Failed to send notification email: %s", mailerr.Error())
+		}
 		return err
 	}
 	_, err = fp.Write([]byte(data))
@@ -106,7 +112,10 @@ func createRegisteredDataset(job *RegistrationJob) error {
 
 	if len(preperrors)+len(warnings) > 0 {
 		// Resend email with errors if any occurred
-		notifyAdmin(job, preperrors, warnings, false)
+		mailerr := notifyAdmin(job, preperrors, warnings, false)
+		if mailerr != nil {
+			log.Printf("Failed to send notification email: %s", mailerr.Error())
+		}
 	}
 	return err
 }

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -357,11 +357,18 @@ type RegistrationRequest struct {
 	ErrorMessages []string
 }
 
+// GetDOIURI replaces scheme and path of the RegistrationRequest.Repository
+// up until the final slash with 'doi/' and returns the string.
+// This method is currently not used in any project and should be
+// considered deprecated.
 func (d *RegistrationRequest) GetDOIURI() string {
 	var re = regexp.MustCompile(`(.+)\/`)
 	return string(re.ReplaceAll([]byte(d.Repository), []byte("doi/")))
 }
 
+// AsHTML returns an HTML encapsulated RegistrationRequest.Message.
+// This method is currently not used in any project and should be
+// considered deprecated.
 func (d *RegistrationRequest) AsHTML() template.HTML {
 	return template.HTML(d.Message)
 }

--- a/cmd/gindoid/dataset_test.go
+++ b/cmd/gindoid/dataset_test.go
@@ -39,7 +39,7 @@ func TestMakeZip(t *testing.T) {
 			if err != nil {
 				return fmt.Errorf("Error creating file %s: %v", currfile, err)
 			}
-			fp.Close()
+			defer fp.Close()
 			return nil
 		}
 		// Create files

--- a/cmd/gindoid/genhtml.go
+++ b/cmd/gindoid/genhtml.go
@@ -10,23 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func readFileAtPath(path string) ([]byte, error) {
-	fp, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-
-	defer fp.Close()
-
-	stat, err := fp.Stat()
-	if err != nil {
-		return nil, err
-	}
-	contents := make([]byte, stat.Size())
-	_, err = fp.Read(contents)
-	return contents, err
-}
-
 // mkhtml reads the provided XML files or URLs and generates the HTML landing
 // page for each.
 func mkhtml(cmd *cobra.Command, args []string) {

--- a/cmd/gindoid/genhtml.go
+++ b/cmd/gindoid/genhtml.go
@@ -3,9 +3,7 @@ package main
 import (
 	"encoding/xml"
 	"fmt"
-	"net/url"
 	"os"
-	"path"
 	"strings"
 
 	"github.com/G-Node/libgin/libgin"
@@ -94,20 +92,4 @@ func mkhtml(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Printf("%d/%d jobs completed successfully\n", success, len(args))
-}
-
-func fetchAndParse(ginurl string, repopath string) (*libgin.RepositoryYAML, error) {
-	repourl, _ := url.Parse(ginurl)
-	repoDatacitePath := path.Join(repopath, "raw", "master", "datacite.yml")
-	repourl.Path = repoDatacitePath
-	fmt.Printf("Fetching metadata from %s\n", repourl.String())
-	infoyml, err := readFileAtURL(repourl.String())
-	if err != nil {
-		return nil, fmt.Errorf("failed to read metadata for repository %q", repopath)
-	}
-	doiInfo, err := readRepoYAML(infoyml)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse metadata for repository %q", repopath)
-	}
-	return doiInfo, nil
 }

--- a/cmd/gindoid/genhtml.go
+++ b/cmd/gindoid/genhtml.go
@@ -58,7 +58,12 @@ func mkhtml(cmd *cobra.Command, args []string) {
 		}
 
 		// if no DOI found in file, just fall back to the argument number
-		os.MkdirAll(metadata.Identifier.ID, 0777)
+		err = os.MkdirAll(metadata.Identifier.ID, 0777)
+		if err != nil {
+			// log and continue with next file
+			fmt.Printf("WARNING: could not create directory %q: %q", metadata.Identifier.ID, err.Error())
+			continue
+		}
 		fname := fmt.Sprintf("%s/index.html", metadata.Identifier.ID)
 		if metadata.Identifier.ID == "" {
 			fmt.Println("WARNING: Couldn't determine DOI. Using generic filename.")

--- a/cmd/gindoid/genhtml.go
+++ b/cmd/gindoid/genhtml.go
@@ -12,12 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	defginurl   = "https://gin.g-node.org"
-	defdoibase  = "10.12751/g-node."
-	defstoreurl = "https://doid.gin.g-node.org"
-)
-
 func readFileAtPath(path string) ([]byte, error) {
 	fp, err := os.Open(path)
 	if err != nil {

--- a/cmd/gindoid/genhtml.go
+++ b/cmd/gindoid/genhtml.go
@@ -119,11 +119,11 @@ func fetchAndParse(ginurl string, repopath string) (*libgin.RepositoryYAML, erro
 	fmt.Printf("Fetching metadata from %s\n", repourl.String())
 	infoyml, err := readFileAtURL(repourl.String())
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read metadata for repository %q\n", repopath)
+		return nil, fmt.Errorf("failed to read metadata for repository %q", repopath)
 	}
 	doiInfo, err := readRepoYAML(infoyml)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse metadata for repository %q\n", repopath)
+		return nil, fmt.Errorf("failed to parse metadata for repository %q", repopath)
 	}
 	return doiInfo, nil
 }

--- a/cmd/gindoid/genhtml.go
+++ b/cmd/gindoid/genhtml.go
@@ -57,17 +57,15 @@ func mkhtml(cmd *cobra.Command, args []string) {
 			}
 		}
 
-		// if no DOI found in file, just fall back to the argument number
-		err = os.MkdirAll(metadata.Identifier.ID, 0777)
-		if err != nil {
-			// log and continue with next file
-			fmt.Printf("WARNING: could not create directory %q: %q", metadata.Identifier.ID, err.Error())
-			continue
-		}
 		fname := fmt.Sprintf("%s/index.html", metadata.Identifier.ID)
+		// If no DOI was found in the file do not create directory and
+		// fall back to the argument number.
 		if metadata.Identifier.ID == "" {
 			fmt.Println("WARNING: Couldn't determine DOI. Using generic filename.")
 			fname = fmt.Sprintf("%03d-index.html", idx)
+		} else if err = os.MkdirAll(metadata.Identifier.ID, 0777); err != nil {
+			fmt.Printf("WARNING: Could not create directory: %q", err.Error())
+			fname = fmt.Sprintf("%s-index.html", metadata.Identifier.ID)
 		}
 		if err := createLandingPage(metadata, fname, ""); err != nil {
 			fmt.Printf("Failed to render landing page for %q: %s\n", filearg, err.Error())

--- a/cmd/gindoid/genhtml.go
+++ b/cmd/gindoid/genhtml.go
@@ -18,16 +18,6 @@ const (
 	defstoreurl = "https://doid.gin.g-node.org"
 )
 
-func isURL(str string) bool {
-	if purl, err := url.Parse(str); err == nil {
-		if purl.Scheme == "" {
-			return false
-		}
-		return true
-	}
-	return false
-}
-
 func readFileAtPath(path string) ([]byte, error) {
 	fp, err := os.Open(path)
 	if err != nil {

--- a/cmd/gindoid/keywords.go
+++ b/cmd/gindoid/keywords.go
@@ -54,7 +54,11 @@ func mkkeywords(cmd *cobra.Command, args []string) {
 		if err != nil {
 			continue
 		}
-		os.MkdirAll(kw, 0777)
+		err = os.MkdirAll(kw, 0777)
+		if err != nil {
+			log.Printf("Could not create the keyword page dir: %s", err.Error())
+			continue
+		}
 
 		fp, err := os.Create(fmt.Sprintf("%s/index.html", kw))
 		if err != nil {

--- a/cmd/gindoid/licenses.go
+++ b/cmd/gindoid/licenses.go
@@ -53,6 +53,7 @@ const defaultLicensesJSON = `[
 	"Name":  "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License",
 	"Alias": [
 	"Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License",
+	"Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International",
 	"Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)",
 	"Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)",
 	"Attribution-NonCommercial-ShareAlike 4.0 International",
@@ -65,6 +66,7 @@ const defaultLicensesJSON = `[
 	"Name":  "Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License",
 	"Alias": [
 	"Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License",
+	"Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International",
 	"Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)",
 	"CC-BY-NC-ND 4.0",
 	"CC-BY-NC-ND"
@@ -75,6 +77,7 @@ const defaultLicensesJSON = `[
 	"Name":  "Creative Commons Attribution-NonCommercial 4.0 International Public License",
 	"Alias": [
 	"Creative Commons Attribution-NonCommercial 4.0 International Public License",
+	"Creative Commons Attribution-NonCommercial 4.0 International",
 	"Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)",
 	"CC BY-NC 4.0",
 	"CC BY-NC"
@@ -85,6 +88,7 @@ const defaultLicensesJSON = `[
 	"Name":  "Creative Commons Attribution-ShareAlike 4.0 International Public License",
 	"Alias": [
 	"Creative Commons Attribution-ShareAlike 4.0 International Public License",
+	"Creative Commons Attribution-ShareAlike 4.0 International",
 	"Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)",
 	"Creative Commons Attribution-ShareAlike 4.0",
 	"CC BY-SA 4.0",
@@ -97,6 +101,7 @@ const defaultLicensesJSON = `[
 	"Alias": [
 	"Creative Commons Attribution 4.0 International Public License",
 	"Creative Commons Attribution 4.0 International License",
+	"Creative Commons Attribution 4.0 International",
 	"Attribution 4.0 International (CC BY 4.0)",
 	"CC BY 4.0",
 	"CC BY"

--- a/cmd/gindoid/mail.go
+++ b/cmd/gindoid/mail.go
@@ -248,15 +248,15 @@ func createIssue(job *RegistrationJob, content string, conf *Configuration) (int
 		log.Printf("Failed to create issue or comment on XML repo: %s", posterr.Error())
 		return -1, posterr
 	} else if resp.StatusCode != http.StatusCreated {
-		if msg, err := ioutil.ReadAll(resp.Body); err == nil {
-			errmsg := fmt.Sprintf("Failed to create issue or comment on XML repo: [%d] %s", resp.StatusCode, msg)
-			log.Printf(errmsg)
-			return -1, fmt.Errorf(errmsg)
+		var errmsg string
+		msg, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			errmsg = fmt.Sprintf("Failed to open issue on XML repo: [%d] failed to read response body: %s", resp.StatusCode, err.Error())
 		} else {
-			msg := fmt.Sprintf("Failed to open issue on XML repo: [%d] failed to read response body: %s", resp.StatusCode, err.Error())
-			log.Print(msg)
-			return -1, fmt.Errorf(msg)
+			errmsg = fmt.Sprintf("Failed to create issue or comment on XML repo: [%d] %s", resp.StatusCode, msg)
 		}
+		log.Print(errmsg)
+		return -1, fmt.Errorf(errmsg)
 	}
 	if existingIssue > 0 {
 		return existingIssue, nil

--- a/cmd/gindoid/mail.go
+++ b/cmd/gindoid/mail.go
@@ -175,7 +175,7 @@ func sendMail(to []string, subject, body string, conf *Configuration) error {
 	// Set the sender and recipient.
 	c.Mail(conf.Email.From)
 	message := fmt.Sprintf("From: %s\nSubject: %s", conf.Email.From, subject)
-	if to != nil && len(to) > 0 {
+	if len(to) > 0 {
 		for _, address := range to {
 			address = strings.TrimSpace(address)
 			log.Printf("To: %s", address)

--- a/cmd/gindoid/mail.go
+++ b/cmd/gindoid/mail.go
@@ -126,7 +126,7 @@ func notifyAdmin(job *RegistrationJob, errors, warnings []string, fullinfo bool)
 	if issueErr != nil && mailErr != nil {
 		// both failed; return error to let the user know that the request failed
 		// The underlying errors are already logged
-		return fmt.Errorf("Failed to notify admins of new request: %s (%s)", job.Metadata.SourceRepository, job.Metadata.Identifier.ID)
+		return fmt.Errorf("failed to notify admins of new request: %s (%s)", job.Metadata.SourceRepository, job.Metadata.Identifier.ID)
 	}
 	return nil
 }

--- a/cmd/gindoid/mail.go
+++ b/cmd/gindoid/mail.go
@@ -226,7 +226,7 @@ func createIssue(job *RegistrationJob, content string, conf *Configuration) (int
 
 	var resp *http.Response
 	var posterr error
-	var existingIssue int64 = 0
+	var existingIssue int64
 	if issueID, err := getIssueID(client, xmlrepo, title); err == nil {
 		if issueID > 0 {
 			// Issue exists: Add comment

--- a/cmd/gindoid/mail.go
+++ b/cmd/gindoid/mail.go
@@ -19,8 +19,10 @@ import (
 )
 
 const (
-	MAILLOG   = "MailServer"
-	DEFAULTTO = "gin@g-node.org" // Fallback email address to notify in case of error
+	// MAILLOG is currently not used in any project and should be considered deprecated.
+	MAILLOG = "MailServer"
+	// DEFAULTTO is a fallback email address to notify in case of error.
+	DEFAULTTO = "gin@g-node.org"
 )
 
 // notifyAdmin prepares an email notification for new jobs and then calls the

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -78,5 +78,8 @@ func main() {
 	rootCmd.SetVersionTemplate("{{.Version}}")
 
 	// Engage
-	rootCmd.Execute()
+	err := rootCmd.Execute()
+	if err != nil {
+		fmt.Printf("Error running gin-doi: %q", err.Error())
+	}
 }

--- a/cmd/gindoid/templaterender_test.go
+++ b/cmd/gindoid/templaterender_test.go
@@ -36,6 +36,9 @@ func TestRequestPageTemplate(t *testing.T) {
 		t.Fatalf("Failed to retrieve datacite.yml from GIN")
 	}
 	doiInfo, err := readRepoYAML(infoyml)
+	if err != nil {
+		t.Fatalf("Failed to read datacite.yaml")
+	}
 	regRequest := new(RegistrationRequest)
 	regRequest.DOIRequestData = &libgin.DOIRequestData{
 		Username:   "testuser",
@@ -111,6 +114,9 @@ func TestLandingPageTemplate(t *testing.T) {
 		t.Fatalf("Failed to retrieve datacite.yml from GIN")
 	}
 	doiInfo, err := readRepoYAML(infoyml)
+	if err != nil {
+		t.Fatalf("Failed to read datacite.yml")
+	}
 	metadata := new(libgin.RepositoryMetadata)
 	metadata.YAMLData = doiInfo
 	metadata.DataCite = libgin.NewDataCiteFromYAML(doiInfo)
@@ -136,6 +142,9 @@ func TestKeywordIndexTemplate(t *testing.T) {
 		t.Fatalf("Failed to retrieve datacite.yml from GIN")
 	}
 	doiInfo, err := readRepoYAML(infoyml)
+	if err != nil {
+		t.Fatalf("Failed to read datacite.yml")
+	}
 	metadata := new(libgin.RepositoryMetadata)
 	metadata.YAMLData = doiInfo
 	metadata.DataCite = libgin.NewDataCiteFromYAML(doiInfo)
@@ -169,6 +178,9 @@ func TestKeywordTemplate(t *testing.T) {
 		t.Fatalf("Failed to retrieve datacite.yml from GIN")
 	}
 	doiInfo, err := readRepoYAML(infoyml)
+	if err != nil {
+		t.Fatalf("Failed to read datatcite.yml")
+	}
 	metadata := new(libgin.RepositoryMetadata)
 	metadata.YAMLData = doiInfo
 	metadata.DataCite = libgin.NewDataCiteFromYAML(doiInfo)

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -167,7 +167,7 @@ func GetGINURL(conf *Configuration) string {
 		return address
 	}
 	scheme := address[:schemeSepIdx]
-	port := address[portSepIdx:len(address)]
+	port := address[portSepIdx:]
 	if (scheme == "http" && port == ":80") ||
 		(scheme == "https" && port == ":443") {
 		// port is standard for scheme: slice it off

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"math/rand"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -53,6 +54,24 @@ func deduplicateValues(dupvals []string) []string {
 		}
 	}
 	return vals
+}
+
+// readFileAtPath returns the content of a file at a given path.
+func readFileAtPath(path string) ([]byte, error) {
+	fp, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	defer fp.Close()
+
+	stat, err := fp.Stat()
+	if err != nil {
+		return nil, err
+	}
+	contents := make([]byte, stat.Size())
+	_, err = fp.Read(contents)
+	return contents, err
 }
 
 // EscXML runs a string through xml.EscapeText.

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -449,7 +449,7 @@ func prepareTemplates(templateNames ...string) (*template.Template, error) {
 	for _, tName := range templateNames {
 		tContent, ok := templateMap[tName]
 		if !ok {
-			return nil, fmt.Errorf("Unknown template with name %q", tName)
+			return nil, fmt.Errorf("unknown template with name %q", tName)
 		}
 		tmpl, err = tmpl.New(tName).Parse(tContent)
 		if err != nil {

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -18,6 +18,7 @@ import (
 	"github.com/G-Node/libgin/libgin"
 )
 
+// ALNUM provides characters for the randAlnum function.
 const ALNUM = "1234567890abcdefghijklmnopqrstuvwxyz"
 
 // randAlnum returns a random alphanumeric (lowercase, latin) string of length 'n'.
@@ -460,6 +461,8 @@ func prepareTemplates(templateNames ...string) (*template.Template, error) {
 	return tmpl, nil
 }
 
+// NewVersionNotice returns an HTML template containing links to a newer version
+// of a given dataset if it exists.
 func NewVersionNotice(md *libgin.RepositoryMetadata) template.HTML {
 	for _, relid := range md.RelatedIdentifiers {
 		if relid.RelationType == "IsOldVersionOf" {
@@ -476,6 +479,8 @@ func NewVersionNotice(md *libgin.RepositoryMetadata) template.HTML {
 	return ""
 }
 
+// OldVersionLink returns an HTML template containing links to a previous version
+// of a given dataset if it exists.
 func OldVersionLink(md *libgin.RepositoryMetadata) template.HTML {
 	for _, relid := range md.RelatedIdentifiers {
 		if relid.RelationType == "IsNewVersionOf" {

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -5,8 +5,10 @@ import (
 	"encoding/xml"
 	"fmt"
 	"html/template"
+	"io/ioutil"
 	"log"
 	"math/rand"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -72,6 +74,28 @@ func readFileAtPath(path string) ([]byte, error) {
 	contents := make([]byte, stat.Size())
 	_, err = fp.Read(contents)
 	return contents, err
+}
+
+// readFileAtURL returns the contents of a file at a given URL.
+func readFileAtURL(url string) ([]byte, error) {
+	client := &http.Client{}
+	log.Printf("Fetching file at %q", url)
+	req, _ := http.NewRequest(http.MethodGet, url, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("Request failed: %s", err.Error())
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request returned non-OK status: %s", resp.Status)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Could not read file contents: %s", err.Error())
+		return nil, err
+	}
+	return body, nil
 }
 
 // EscXML runs a string through xml.EscapeText.

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/md5"
-	"encoding/hex"
 	"encoding/xml"
 	"fmt"
 	"html/template"
@@ -59,14 +57,6 @@ var tmplfuncs = template.FuncMap{
 	"NewVersionNotice": NewVersionNotice,
 	"OldVersionLink":   OldVersionLink,
 	"GINServerURL":     GINServerURL,
-}
-
-func makeUUID(URI string) string {
-	if doi, ok := libgin.UUIDMap[URI]; ok {
-		return doi
-	}
-	currMd5 := md5.Sum([]byte(URI))
-	return hex.EncodeToString(currMd5[:])
 }
 
 // deduplicateValues checks a string slice for duplicate

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -32,6 +33,15 @@ func randAlnum(n int) string {
 	}
 
 	return string(chrs)
+}
+
+// isURL returns true if a URL scheme part can be identfied
+// within a passed string. Returns false in any other case.
+func isURL(str string) bool {
+	if purl, err := url.Parse(str); err == nil {
+		return purl.Scheme != ""
+	}
+	return false
 }
 
 // Global function map for the templates that render the DOI information

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -7,10 +7,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"math/rand"
-	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -61,12 +59,6 @@ var tmplfuncs = template.FuncMap{
 	"NewVersionNotice": NewVersionNotice,
 	"OldVersionLink":   OldVersionLink,
 	"GINServerURL":     GINServerURL,
-}
-
-func readBody(r *http.Request) (*string, error) {
-	body, err := ioutil.ReadAll(r.Body)
-	x := string(body)
-	return &x, err
 }
 
 func makeUUID(URI string) string {

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -50,11 +50,17 @@ func TestReadFileAtURL(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/invalid", func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusNotFound)
-		rw.Write([]byte(`non-OK`))
+		_, err := rw.Write([]byte(`non-OK`))
+		if err != nil {
+			t.Fatalf("Could not write invalid response: %q", err.Error())
+		}
 	})
 	mux.HandleFunc("/valid", func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
-		rw.Write([]byte(`OK`))
+		_, err := rw.Write([]byte(`OK`))
+		if err != nil {
+			t.Fatalf("Could not write valid response: %q", err.Error())
+		}
 	})
 
 	// Start local test server

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -116,3 +116,16 @@ func TestFunderName(t *testing.T) {
 		t.Fatalf("Fundername 'issues' parse error: (in) '%s' (out) '%s' (expect) '%s'", instr, outstr, subnameclean)
 	}
 }
+
+// TestIsURL tests proper URL identification via util.isURL.
+func TestIsURL(t *testing.T) {
+	testURL := "i/am/no/url"
+	if isURL(testURL) {
+		t.Fatalf("isURL returned true for test string %q", testURL)
+	}
+
+	testURL = "https://i/could/be/a/url"
+	if !isURL(testURL) {
+		t.Fatalf("isURL returned false for test string %q", testURL)
+	}
+}

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -2,9 +2,41 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestReadFileAtPath(t *testing.T) {
+	_, err := readFileAtPath("I/do/not/exist")
+	if err == nil {
+		t.Fatal("Missing error opening non existant file.")
+	}
+
+	tmpDir, err := ioutil.TempDir("", "test_gindoi_licfromfile")
+	if err != nil {
+		t.Fatalf("Error creating tmp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tmpfile := filepath.Join(tmpDir, "tmp.json")
+	tmpcont := `[{"some": "data"}]`
+	err = writeTmpFile(tmpfile, tmpcont)
+	if err != nil {
+		t.Fatalf("Error creating tmp file: %q", err.Error())
+	}
+
+	cont, err := readFileAtPath(tmpfile)
+	if err != nil {
+		t.Fatalf("Error reading tmp file: %q", err.Error())
+	}
+	if strings.Compare(tmpcont, string(cont)) != 0 {
+		t.Fatalf("Issues reading file content: %q", cont)
+	}
+}
 
 func TestDeduplicateValues(t *testing.T) {
 	// check empty

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -313,7 +313,7 @@ func checkMissingValues(info *libgin.RepositoryYAML) []string {
 
 func contains(list []string, value string) bool {
 	for _, valid := range list {
-		if strings.ToLower(valid) == strings.ToLower(value) {
+		if strings.EqualFold(valid, value) {
 			return true
 		}
 	}

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -153,7 +153,7 @@ func TestLicFromName(t *testing.T) {
 	}
 }
 
-func TestCleanupcompstr(t *testing.T) {
+func TestCleancompstr(t *testing.T) {
 	instr := "  aLLcasEs  "
 	expected := "allcases"
 	outstr := cleancompstr(instr)

--- a/cmd/gindoid/web.go
+++ b/cmd/gindoid/web.go
@@ -141,7 +141,10 @@ func renderRequestPage(w http.ResponseWriter, r *http.Request, conf *Configurati
 		}
 		// Overwrite default GIN server URL with config GIN server URL
 		tmpl = injectDynamicGINURL(tmpl, GetGINURL(conf))
-		tmpl.Execute(w, regRequest)
+		err = tmpl.Execute(w, regRequest)
+		if err != nil {
+			log.Printf("Failed to execute RequestFailurePage template: %q", err.Error())
+		}
 		return
 	}
 
@@ -162,7 +165,10 @@ func renderRequestPage(w http.ResponseWriter, r *http.Request, conf *Configurati
 		}
 		// Overwrite default GIN server URL with config GIN server URL
 		tmpl = injectDynamicGINURL(tmpl, GetGINURL(conf))
-		tmpl.Execute(w, regRequest)
+		err = tmpl.Execute(w, regRequest)
+		if err != nil {
+			log.Printf("Failed to execute RequestFailurePage template: %q", err.Error())
+		}
 		return
 	}
 

--- a/cmd/gindoid/web.go
+++ b/cmd/gindoid/web.go
@@ -337,7 +337,10 @@ func renderResult(w http.ResponseWriter, resData *reqResultData, conf *Configura
 		log.Printf("Failed to parse requestresult template: %s", err.Error())
 		log.Printf("Request data: %+v", resData)
 		// failed to render result template; just show the message wrapped in html tags
-		w.Write([]byte("<html>" + resData.Message + "</html>"))
+		_, err = w.Write([]byte("<html>" + resData.Message + "</html>"))
+		if err != nil {
+			log.Printf("Failed to write fallback page: %s", err.Error())
+		}
 		return
 	}
 	// Overwrite default GIN server URL with config GIN server URL

--- a/cmd/gindoid/web_test.go
+++ b/cmd/gindoid/web_test.go
@@ -23,7 +23,10 @@ func TestInjectDynamicGINURL(t *testing.T) {
 		t.Fatalf("Failed to parse test template: %s", err.Error())
 	}
 	tmpl = injectDynamicGINURL(tmpl, "")
-	tmpl.Execute(&b, data)
+	err = tmpl.Execute(&b, data)
+	if err != nil {
+		t.Fatalf("Failed to execute test template: %s", err.Error())
+	}
 	if checkurl != b.String() {
 		t.Fatalf("Error default URL; got: '%s'", b.String())
 	}
@@ -38,7 +41,10 @@ func TestInjectDynamicGINURL(t *testing.T) {
 		t.Fatalf("Failed to parse test template: %s", err.Error())
 	}
 	tmpl = injectDynamicGINURL(tmpl, dynamicurl)
-	tmpl.Execute(&b, data)
+	err = tmpl.Execute(&b, data)
+	if err != nil {
+		t.Fatalf("Failed to execute test template: %s", err.Error())
+	}
 	if checkurl != b.String() {
 		t.Fatalf("Error dynamic URL; got: '%s'", b.String())
 	}

--- a/cmd/gindoid/workdispatcher.go
+++ b/cmd/gindoid/workdispatcher.go
@@ -62,13 +62,6 @@ func (w *Worker) start() {
 	}()
 }
 
-// stop the worker.
-func (w *Worker) stop() {
-	go func() {
-		w.QuitChan <- true
-	}()
-}
-
 // newDispatcher creates and returns a new Dispatcher object that holds all
 // waiting jobs and sends the next job in the queue to the first available
 // worker.
@@ -102,6 +95,7 @@ func (d *Dispatcher) run(makeWorker func(int, chan chan *RegistrationJob) Worker
 }
 
 func (d *Dispatcher) dispatch() {
+	//lint:ignore S1000 rewrite to suggested range syntax leads to loop variable i captured by func literal issue.
 	for {
 		select {
 		case job := <-d.jobQueue:

--- a/cmd/gindoid/workdispatcher.go
+++ b/cmd/gindoid/workdispatcher.go
@@ -31,6 +31,8 @@ func newWorker(id int, workerPool chan chan *RegistrationJob) Worker {
 	}
 }
 
+// Worker holds a JobQueue that will accept and handle incoming
+// DOI registration jobs.
 type Worker struct {
 	ID         int
 	JobQueue   chan *RegistrationJob
@@ -77,6 +79,8 @@ func newDispatcher(jobQueue chan *RegistrationJob, maxWorkers int) *Dispatcher {
 	}
 }
 
+// Dispatcher holds waiting jobs and sends the next job in the queue to
+// the first available worker.
 type Dispatcher struct {
 	workerPool chan chan *RegistrationJob
 	maxWorkers int

--- a/cmd/gindoid/workdispatcher.go
+++ b/cmd/gindoid/workdispatcher.go
@@ -48,8 +48,11 @@ func (w *Worker) start() {
 			w.WorkerPool <- w.JobQueue
 			select {
 			case job := <-w.JobQueue:
-				// Dispatcher has added a job to my jobQueue.
-				createRegisteredDataset(job)
+				// Dispatcher has added a job to my jobQueue
+				err := createRegisteredDataset(job)
+				if err != nil {
+					log.Printf("Encountered issue handling request: %q", err.Error())
+				}
 				log.Printf("Worker %d Completed %q!", w.ID, job.Metadata.SourceRepository)
 			case <-w.QuitChan:
 				// We have been asked to stop.

--- a/templates/common.go
+++ b/templates/common.go
@@ -20,6 +20,7 @@ const Nav = `
 			</div>
 `
 
+// Footer is the template for every page footer
 const Footer = `
 		<footer>
 			<div class="ui container">

--- a/templates/keyword.go
+++ b/templates/keyword.go
@@ -1,5 +1,7 @@
 package gdtmpl
 
+// Keyword is the template for an HTML page
+// linking DOI pages featuring a specifc keyword.
 const Keyword = `<!DOCTYPE html>
 <html lang="en">
 	<head>

--- a/templates/kwindex.go
+++ b/templates/kwindex.go
@@ -1,5 +1,7 @@
 package gdtmpl
 
+// KeywordIndex is the template for an HTML page listing links
+// to all available keyword pages.
 const KeywordIndex = `<!DOCTYPE html>
 <html lang="en">
 	<head>


### PR DESCRIPTION
This PR removes all reported code issues by `go lint` `staticcheck` and `errcheck` and updates the github actions file to now fail on reported issues from `go lint`  and `staticcheck`.

The following constants, functions or methods are removed since they are no longer used:
- `genhtml.go`: `const defginurl`, `const defdoibase`, `const defstoreurl`, `func fetchAndParse`
- `util.go`: `func readBody`, `func makeUUID`
- `workerdispatcher.go`: method `Worker.stop`

The following functions have been moved to `util.go` since they were used by other package files as well:
- `genhtml.go`: `readFileAtPath`, `isURL`
- `dataset.go`: `readFileAtURL`

The following tests have been added:
- util.isURL test
- util.readFileAtPath test
- util.readFileAtURL test