### PR TITLE
Command line tool to generate doi.xml files

### DIFF
--- a/cmd/gindoid/genxml.go
+++ b/cmd/gindoid/genxml.go
@@ -107,5 +107,5 @@ func mkxml(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Printf("%d/%d jobs completed successfully\n", success, len(args))
-	fmt.Print("Check and adjust sizes and publication dates\n")
+	fmt.Print("\nRemember to add the G-Node identifier and check and adjust sizes and publication dates\n")
 }

--- a/cmd/gindoid/genxml.go
+++ b/cmd/gindoid/genxml.go
@@ -107,4 +107,5 @@ func mkxml(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Printf("%d/%d jobs completed successfully\n", success, len(args))
+	fmt.Print("Check and adjust sizes and publication dates\n")
 }

--- a/cmd/gindoid/genxml.go
+++ b/cmd/gindoid/genxml.go
@@ -4,10 +4,25 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/G-Node/libgin/libgin"
 	"github.com/spf13/cobra"
 )
+
+// cleanupGINURL returns owner and repository of a GIN
+// repository datacite URL string. Example:
+// https://gin.g-node.org/G-Node/doi_deployment_test/raw/master/datacite.yml
+func cleanupGINURL(input string) (string, error) {
+	cleanstr := strings.Replace(input, "https://gin.g-node.org/", "", -1)
+	cleanstr = strings.Replace(cleanstr, "/raw/master/datacite.yml", "", -1)
+	out := strings.Split(cleanstr, "/")
+
+	if len(out) != 2 {
+		return "", fmt.Errorf("could not parse URL: %s", input)
+	}
+	return out[1], nil
+}
 
 // mkxml reads one or more datacite YAML files from GIN, a provided URL or from 
 // a direct file and generates a Datacite XML file for each.
@@ -22,6 +37,10 @@ func mkxml(cmd *cobra.Command, args []string) {
 		var err error
 		var repoName string
 		if isURL(filearg) {
+			repoName, err = cleanupGINURL(filearg)
+			if err != nil {
+				fmt.Printf("failed to cleanup GIN datacite URL: %s", err.Error())
+			}
 			contents, err = readFileAtURL(filearg)
 		} else {
 			contents, err = readFileAtPath(filearg)

--- a/cmd/gindoid/genxml.go
+++ b/cmd/gindoid/genxml.go
@@ -10,21 +10,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// cleanupGINURL returns owner and repository of a GIN
-// repository datacite URL string. Example:
-// https://gin.g-node.org/G-Node/doi_deployment_test/raw/master/datacite.yml
-func cleanupGINURL(input string) (string, error) {
-	cleanstr := strings.Replace(input, "https://gin.g-node.org/", "", -1)
-	cleanstr = strings.Replace(cleanstr, "/raw/master/datacite.yml", "", -1)
-	out := strings.Split(cleanstr, "/")
-
-	if len(out) != 2 {
-		return "", fmt.Errorf("could not parse URL: %s", input)
+// getGINDataciteURL returns a full URL to the datacite file at
+// the root of a GIN repository where owner and repository name
+// were provided as a single input string.
+func getGINDataciteURL(input string) (string, error) {
+	inputslice := strings.Split(input, "/")
+	if len(inputslice) != 2 {
+		return "", fmt.Errorf("could not parse gin repo string %s", input)
 	}
-	return out[1], nil
+
+	ginprefix := "https://gin.g-node.org/"
+	ginpostfix := "/raw/master/datacite.yml"
+	out := fmt.Sprintf("%s%s%s", ginprefix, input, ginpostfix)
+
+	return out, nil
 }
 
-// mkxml reads one or more datacite YAML files from GIN, a provided URL or from 
+// mkxml reads one or more datacite YAML files from GIN, a provided URL or from
 // a direct file and generates a Datacite XML file for each.
 // Reading files from GIN requires only the repository owner and the repository name
 // of the GIN repository prefixed with GIN in the format "GIN:[owner]/[repository]"
@@ -36,11 +38,23 @@ func mkxml(cmd *cobra.Command, args []string) {
 		var contents []byte
 		var err error
 		var repoName string
-		if isURL(filearg) {
-			repoName, err = cleanupGINURL(filearg)
+		if strings.HasPrefix(filearg, "GIN:") {
+			repostring := strings.Replace(filearg, "GIN:", "", 1)
+			ginurl, err := getGINDataciteURL(repostring)
 			if err != nil {
-				fmt.Printf("failed to cleanup GIN datacite URL: %s", err.Error())
+				fmt.Printf("Failed to parse GIN specific repo string: %s\n", filearg)
+				continue
 			}
+			repodata := strings.Split(repostring, "/")
+			if len(repodata) == 2 {
+				repoName = repodata[1]
+			}
+			contents, err = readFileAtURL(ginurl)
+			if err != nil {
+				fmt.Printf("Failed to read file at %q: %s\n", ginurl, err.Error())
+				continue
+			}
+		} else if isURL(filearg) {
 			contents, err = readFileAtURL(filearg)
 		} else {
 			contents, err = readFileAtPath(filearg)
@@ -52,7 +66,7 @@ func mkxml(cmd *cobra.Command, args []string) {
 
 		dataciteContent, err := readRepoYAML(contents)
 		if err != nil {
-			fmt.Print("DOI file invalid")
+			fmt.Print("DOI file invalid\n")
 			continue
 		}
 

--- a/cmd/gindoid/genxml.go
+++ b/cmd/gindoid/genxml.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// mkxml reads one or more datacite YAML files from GIN, a provided URL or from 
+// a direct file and generates a Datacite XML file for each.
+// Reading files from GIN requires only the repository owner and the repository name
+// of the GIN repository prefixed with GIN in the format "GIN:[owner]/[repository]"
+func mkxml(cmd *cobra.Command, args []string) {
+	fmt.Printf("Generating %d xml files\n", len(args))
+}

--- a/cmd/gindoid/genxml.go
+++ b/cmd/gindoid/genxml.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
+	"github.com/G-Node/libgin/libgin"
 	"github.com/spf13/cobra"
 )
 
@@ -12,4 +15,63 @@ import (
 // of the GIN repository prefixed with GIN in the format "GIN:[owner]/[repository]"
 func mkxml(cmd *cobra.Command, args []string) {
 	fmt.Printf("Generating %d xml files\n", len(args))
+	var success int
+	for idx, filearg := range args {
+		fmt.Printf("%3d: %s\n", idx, filearg)
+		var contents []byte
+		var err error
+		var repoName string
+		if isURL(filearg) {
+			contents, err = readFileAtURL(filearg)
+		} else {
+			contents, err = readFileAtPath(filearg)
+		}
+		if err != nil {
+			fmt.Printf("Failed to read file at %q: %s\n", filearg, err.Error())
+			continue
+		}
+
+		dataciteContent, err := readRepoYAML(contents)
+		if err != nil {
+			fmt.Print("DOI file invalid")
+			continue
+		}
+
+		datacite := libgin.NewDataCiteFromYAML(dataciteContent)
+
+		// Create storage directory
+		if repoName == "" {
+			repoName = fmt.Sprintf("index-%03d", idx)
+		}
+		fname := filepath.Join(repoName, "doi.xml")
+		if err = os.MkdirAll(repoName, 0777); err != nil {
+			fmt.Printf("WARNING: Could not create directory %s: %q", repoName, err.Error())
+			fname = fmt.Sprintf("%s-doi.xml", repoName)
+		}
+
+		fp, err := os.Create(fname)
+		if err != nil {
+			// XML Creation failed; return with error
+			fmt.Printf("Failed to create the XML metadata file: %s", err)
+			continue
+		}
+		defer fp.Close()
+
+		data, err := datacite.Marshal()
+		if err != nil {
+			fmt.Printf("Failed to render the XML metadata file: %s", err)
+			continue
+		}
+		_, err = fp.Write([]byte(data))
+		if err != nil {
+			fmt.Printf("Failed to write the metadata XML file: %s", err)
+			continue
+		}
+
+		fmt.Printf("\t-> %s\n", fname)
+		// all good
+		success++
+	}
+
+	fmt.Printf("%d/%d jobs completed successfully\n", success, len(args))
 }

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -71,7 +71,7 @@ Previously generated pages are overwritten, so this command only makes sense if 
 		Short: "Generate the doi.xml file from one or more DataCite YAML files",
 		Long: `Generate the doi.xml file from one or more DataCite YAML files.
 
-The command accepts file paths and URLs (mixing allowed) and will generate one XML file for each YAML file found. If the page generation requires information that is missing from the XML file (e.g., archive file size, repository URLs), the program will attempt to retrieve the metadata by querying the online resources. If that fails, a warning is printed and the file is still generated with the available information. Contextual information like size or date have to be added manually.`,
+The command accepts GIN repositories of format "GIN:owner/repository", yaml file paths and URLs to yaml files (mixing allowed) and will generate one XML file for each YAML file found. If the page generation requires information that is missing from the XML file (e.g., archive file size, repository URLs), the program will attempt to retrieve the metadata by querying the online resources. If that fails, a warning is printed and the file is still generated with the available information. Contextual information like size or date have to be added manually.`,
 		Args:                  cobra.MinimumNArgs(1),
 		Run:                   mkxml,
 		Version:               verstr,

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -25,7 +25,7 @@ func setUpCommands(verstr string) *cobra.Command {
 		Version:               fmt.Sprintln(verstr),
 		DisableFlagsInUseLine: true,
 	}
-	cmds := make([]*cobra.Command, 4)
+	cmds := make([]*cobra.Command, 5)
 	cmds[0] = &cobra.Command{
 		Use:                   "start",
 		Short:                 "Start the GIN DOI service",
@@ -66,6 +66,17 @@ Previously generated pages are overwritten, so this command only makes sense if 
 		Version:               verstr,
 		DisableFlagsInUseLine: true,
 	}
+	cmds[4] = &cobra.Command{
+		Use:   "make-doi-xml <yml file>...",
+		Short: "Generate the doi.xml file from one or more DataCite YAML files",
+		Long: `Generate the doi.xml file from one or more DataCite YAML files.
+
+The command accepts file paths and URLs (mixing allowed) and will generate one XML file for each YAML file found. If the page generation requires information that is missing from the XML file (e.g., archive file size, repository URLs), the program will attempt to retrieve the metadata by querying the online resources. If that fails, a warning is printed and the file is still generated with the available information. Contextual information like size or date have to be added manually.`,
+		Args:                  cobra.MinimumNArgs(1),
+		Run:                   mkxml,
+		Version:               verstr,
+		DisableFlagsInUseLine: true,
+	}
 
 	rootCmd.AddCommand(cmds...)
 	return rootCmd
@@ -80,6 +91,6 @@ func main() {
 	// Engage
 	err := rootCmd.Execute()
 	if err != nil {
-		fmt.Printf("Error running gin-doi: %q", err.Error())
+		fmt.Printf("Error running gin-doi: %q\n", err.Error())
 	}
 }

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -67,7 +67,7 @@ Previously generated pages are overwritten, so this command only makes sense if 
 		DisableFlagsInUseLine: true,
 	}
 	cmds[4] = &cobra.Command{
-		Use:   "make-doi-xml <yml file>...",
+		Use:   "make-xml <yml file>...",
 		Short: "Generate the doi.xml file from one or more DataCite YAML files",
 		Long: `Generate the doi.xml file from one or more DataCite YAML files.
 

--- a/go.mod
+++ b/go.mod
@@ -20,11 +20,13 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.6.2 // indirect
+	github.com/stretchr/testify v1.6.1 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
 	golang.org/x/text v0.3.3 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/ini.v1 v1.55.0 // indirect
-	gopkg.in/yaml.v2 v2.2.8
+	gopkg.in/yaml.v2 v2.3.0
 )
 
 replace github.com/docker/docker => github.com/docker/engine v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -234,6 +236,8 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.55.0 h1:E8yzL5unfpW3M6fz/eB7Cb5MQAYSZ7GKo4Qth+N2sgQ=
@@ -243,8 +247,10 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099 h1:XJP7lxbSxWLOMNdBE4B/STaqVy6L73o0knwj2vIlxnw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Analogous to the `make-html` command line option of the gindoid binary, this PR adds the `make-doi-xml` command line option.

When provided a datacite.yml file, a URL to a datacite.yaml file or a public GIN repository containing a valid datacite.yaml file in the format `GIN:owner/repo`  the binary will create corresponding `doi.xml` files.

e.g. `./gindoid make-doi-xml GIN:jgrewe/grewe_etal_synchrony local_datacite.yml https://gin.g-node.org/jgrewe/grewe_etal_synchrony/raw/master/doi_info.xml`