### PR TITLE
Secondary content download, change precheck workflow and git submodule warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+.vscode 
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -361,40 +361,45 @@ func (d *RegistrationRequest) AsHTML() template.HTML {
 	return template.HTML(d.Message)
 }
 
-// readAndValidate loads the datacite.yml file at the given URL, validates it
+// readAndValidate loads and checks LICENSE file and datacite.yml file for a
+// given repository. The function tries to collect as many issues as possible
 // and returns the RepositoryYAML struct or an error message if the retrieval,
 // parsing, or validation fails.  The message is appropriate for display to the
 // user.
 func readAndValidate(conf *Configuration, repository string) (*libgin.RepositoryYAML, error) {
-	// fail registration on missing datacite.yaml file
-	dataciteText, err := readFileAtURL(repoFileURL(conf, repository, "datacite.yml"))
-	if err != nil {
-		// Can happen if the datacite.yml file is removed and the user clicks the register button on a stale page
-		err := fmt.Errorf("%s <p><i>No datacite.yml file found in repository</i></p>", msgInvalidDOI)
-		return nil, err
-	}
-
-	// fail registration on invalid datacite.yaml file
-	repoMetadata, err := readRepoYAML(dataciteText)
-	if err != nil {
-		log.Print("DOI file invalid")
-		// reformat error messages
-		msgs := strings.Split(err.Error(), "; ")
-		err := fmt.Errorf("%s<div align='left' style='padding-left: 50px;'><i><ul><li>%s</li></ul></i></div>", msgInvalidDOI, strings.Join(msgs, "</li><li>"))
-		return nil, err
-	}
-
-	// fail registration on missing LICENSE file
-	_, err = readFileAtURL(repoFileURL(conf, repository, "LICENSE"))
+	// Fail registration on missing LICENSE file; do not yet return and check datacite.yml
+	collecterr := make([]string, 0)
+	_, err := readFileAtURL(repoFileURL(conf, repository, "LICENSE"))
 	if err != nil {
 		log.Printf("Failed to fetch LICENSE: %s", err.Error())
-		return nil, fmt.Errorf("<p>%s</p>", msgNoLicenseFile)
+		collecterr = append(collecterr, fmt.Sprintf("<p>%s</p>", msgNoLicenseFile))
 	}
 
-	// fail registration if unsupported values have been used
-	if msgs := validateDataCiteValues(repoMetadata); len(msgs) > 0 {
-		err := fmt.Errorf("%s<div align='left' style='padding-left: 50px;'><i><ul><li>%s</li></ul></i></div>", msgInvalidDOI, strings.Join(msgs, "</li><li>"))
-		return nil, err
+	// Fail registration on missing datacite.yaml file; can happen if the datacite.yml file
+	// is removed and the user clicks the register button on a stale page
+	dataciteText, err := readFileAtURL(repoFileURL(conf, repository, "datacite.yml"))
+	if err != nil {
+		log.Printf("Failed to fetch datacite.yml: %s", err.Error())
+		collecterr = append(collecterr, fmt.Sprintf("<p>%s</p>", msgInvalidDOI))
+		return nil, fmt.Errorf(strings.Join(collecterr, "<br>"))
+	}
+
+	// Fail registration on invalid datacite.yaml file
+	repoMetadata, err := readRepoYAML(dataciteText)
+	if err != nil {
+		log.Printf("DOI file invalid: %s", err.Error())
+		collecterr = append(collecterr, fmt.Sprintf("<p>%s<i>%s</i></p>", msgInvalidDOI, err.Error()))
+		return nil, fmt.Errorf(strings.Join(collecterr, "<br>"))
+	}
+	// Fail registration if any required validation fails
+	if msgs := validateDataCite(repoMetadata); len(msgs) > 0 {
+		log.Print("DOI file contains validation issues")
+		fmtstring := "%s<div align='left' style='padding-left: 50px;'><i><ul><li>%s</li></ul></i></div>"
+		collecterr = append(collecterr, fmt.Sprintf(fmtstring, msgInvalidDOI, strings.Join(msgs, "</li><li>")))
+	}
+
+	if len(collecterr) > 0 {
+		return nil, fmt.Errorf(strings.Join(collecterr, "<br>"))
 	}
 
 	return repoMetadata, nil

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -388,7 +388,7 @@ func readAndValidate(conf *Configuration, repository string) (*libgin.Repository
 	repoMetadata, err := readRepoYAML(dataciteText)
 	if err != nil {
 		log.Printf("DOI file invalid: %s", err.Error())
-		collecterr = append(collecterr, fmt.Sprintf("<p>%s<i>%s</i></p>", msgInvalidDOI, err.Error()))
+		collecterr = append(collecterr, fmt.Sprintf("<p>%s<br>Error details: <i>%s</i></p>", msgInvalidDOI, err.Error()))
 		return nil, fmt.Errorf(strings.Join(collecterr, "<br>"))
 	}
 	// Fail registration if any required validation fails

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -324,11 +324,6 @@ func readRepoYAML(infoyml []byte) (*libgin.RepositoryYAML, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error while reading DOI info: %s", err.Error())
 	}
-	if missing := checkMissingValues(yamlInfo); len(missing) > 0 {
-		missing = deduplicateValues(missing)
-		log.Print("DOI file is missing entries")
-		return nil, fmt.Errorf(strings.Join(missing, "; "))
-	}
 	return yamlInfo, nil
 }
 

--- a/cmd/gindoid/dataset_test.go
+++ b/cmd/gindoid/dataset_test.go
@@ -142,3 +142,16 @@ func TestMakeZip(t *testing.T) {
 		t.Fatalf("Zip does not include correct number of elements: %v/%v\n%v", len(includedCounter), len(incl), includedCounter)
 	}
 }
+
+func TestReadRepoYAML(t *testing.T) {
+	invalid := "<xml>I am not a yaml file</xml>"
+	_, err := readRepoYAML([]byte(invalid))
+	if err == nil {
+		t.Fatalf("Expected YAML read error")
+	}
+	valid := "key: value"
+	_, err = readRepoYAML([]byte(valid))
+	if err != nil {
+		t.Fatalf("Could not read YAML")
+	}
+}

--- a/cmd/gindoid/genxml.go
+++ b/cmd/gindoid/genxml.go
@@ -66,8 +66,13 @@ func mkxml(cmd *cobra.Command, args []string) {
 
 		dataciteContent, err := readRepoYAML(contents)
 		if err != nil {
-			fmt.Print("DOI file invalid\n")
+			fmt.Printf("DOI file invalid: %s\n", err.Error())
 			continue
+		}
+
+		// Add datacite quality checks and notify but carry on
+		if msgs := validateDataCite(dataciteContent); len(msgs) > 0 {
+			fmt.Printf("DOI file contains validation issues: %s\n", strings.Join(msgs, "; "))
 		}
 
 		datacite := libgin.NewDataCiteFromYAML(dataciteContent)

--- a/cmd/gindoid/messages.go
+++ b/cmd/gindoid/messages.go
@@ -34,14 +34,14 @@ If you would like to make any changes to the dataset before it is published, or 
 	msgNotLoggedIn      = `You are not logged in with the gin service. Login <a href="http://gin.g-node.org/">here</a>`
 	msgNoToken          = "No authentication token provided"
 	msgNoUser           = "No username provided"
-	msgNoTitle          = "No title provided."
-	msgNoAuthors        = "No authors provided."
+	msgNoTitle          = `No <b>title</b> provided.`
+	msgNoAuthors        = `No <b>authors</b> provided.`
 	msgInvalidAuthors   = "Not all authors valid. Please provide at least a last name and a first name."
-	msgNoDescription    = "No description provided."
-	msgNoLicense        = "No valid license provided. Please specify a license URL and name and make sure it matches the license file in the repository."
+	msgNoDescription    = `No <b>description</b> provided.`
+	msgNoLicense        = `No valid <b>license</b> provided. Please specify a license URL and name and make sure it matches the license file in the repository.`
 	msgNoLicenseFile    = `The LICENSE file is missing. The full text of the license is required to be in the repository when publishing. See the <a href="https://gin.g-node.org/G-Node/Info/wiki/Licensing">Licensing</a> help page for details and links to recommended data licenses.`
 	msgLicenseMismatch  = `The LICENSE file does not match the license specified in the metadata. See the <a href="https://gin.g-node.org/G-Node/Info/wiki/Licensing">Licensing</a> help page for links to full text for available licenses.`
-	msgInvalidReference = "Not all Reference entries are valid. Please provide the full citation and type of the reference."
+	msgInvalidReference = `Not all <b>Reference</b> entries are valid. Please provide the full citation and type of the reference.`
 	msgBadEncoding      = `There was an issue with the content of the DOI file (datacite.yml). This might mean that the encoding is wrong. Please see <a href="https://gin.g-node.org/G-Node/Info/wiki/DOIfile">the DOI guide</a> for detailed instructions or contact gin@g-node.org for assistance.`
 
 	msgSubmitError     = "An internal error occurred while we were processing your request.  The G-Node team has been notified of the problem and will attempt to repair it and process your request.  We may contact you for further information regarding your request.  Feel free to <a href=mailto:gin@g-node.org>contact us</a> if you would like to provide more information or ask about the status of your request."

--- a/cmd/gindoid/templaterender_test.go
+++ b/cmd/gindoid/templaterender_test.go
@@ -13,6 +13,7 @@ func TestRequestFailureTemplate(t *testing.T) {
 	regRequest := new(RegistrationRequest)
 	regRequest.Message = template.HTML(msgInvalidRequest)
 	regRequest.Metadata = new(libgin.RepositoryMetadata)
+	regRequest.DOIRequestData = new(libgin.DOIRequestData) // Source repo required to render fail page
 	tmpl, err := prepareTemplates("RequestFailurePage")
 	if err != nil {
 		t.Fatalf("Failed to parse RequestFailureP template: %s", err.Error())

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -233,6 +233,7 @@ var tmplfuncs = template.FuncMap{
 	"NewVersionNotice": NewVersionNotice,
 	"OldVersionLink":   OldVersionLink,
 	"GINServerURL":     GINServerURL,
+	"HasGitModules":    HasGitModules,
 }
 
 // FunderName splits the funder name from a funding string of the form <FunderName>; <AwardNumber>.
@@ -550,4 +551,13 @@ func URLexists(url string) bool {
 	}
 
 	return false
+}
+
+// HasGitModules checks whether a repository on the defined GIN
+// server features a '.gitmodules' file and returns the result as boolean.
+func HasGitModules(ginurl string, repo string) bool {
+	moduleurl := fmt.Sprintf("%s/%s/src/master/.gitmodules", ginurl, repo)
+	log.Printf("HasGitModules: checking url %s", moduleurl)
+
+	return URLexists(moduleurl)
 }

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -535,3 +535,19 @@ func OldVersionLink(md *libgin.RepositoryMetadata) template.HTML {
 func GINServerURL() string {
 	return "https://gin.g-node.org"
 }
+
+// URLexists runs a GET against an URL, returns true if
+// the return code is 200 and false otherwise.
+func URLexists(url string) bool {
+	response, err := http.Get(url)
+	if err != nil {
+		log.Printf("URLexists: error accessing url %s: %s", url, err.Error())
+		return false
+	}
+
+	if response.StatusCode == http.StatusOK {
+		return true
+	}
+
+	return false
+}

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -320,6 +320,16 @@ func contains(list []string, value string) bool {
 	return false
 }
 
+// validateDataCite runs all datacite checks and aggregates and
+// returns a slice with all collected and deduplicated error messages.
+// The slice is empty if all checks returned valid.
+func validateDataCite(info *libgin.RepositoryYAML) []string {
+	msgs := checkMissingValues(info)
+	msgs = deduplicateValues(msgs)
+	msgs = append(msgs, validateDataCiteValues(info)...)
+	return msgs
+}
+
 // validateDataCiteValues checks if the datacite keys that have limited value
 // options have a valid value.  Returns a slice of error messages to display to
 // the user.  The slice is empty if all values are valid.

--- a/templates/reqfail.go
+++ b/templates/reqfail.go
@@ -41,7 +41,7 @@ const RequestFailurePage = `<!DOCTYPE html>
 								<a class="item brand" href="{{GINServerURL}}/">
 									<img class="ui mini image" src="/assets/img/favicon.png">
 								</a>
-								<a class="item active" href="{{GINServerURL}}/">Back to GIN</a>
+								<a class="item active" href="{{GINServerURL}}/{{.Repository}}">Back to GIN</a>
 							</div>
 						</div>
 					</div>

--- a/templates/reqpage.go
+++ b/templates/reqpage.go
@@ -79,6 +79,7 @@ const RequestPage = `<!DOCTYPE html>
 								</ul>
 							</div>
 							<p><b>Please be aware that the entire repository will be published.</b></p>
+							<p><b>Please note that content linked via git submodules will not be included in the published dataset.</b></p>
 							<p><b>Please make sure it does not contain any private files, SSH keys, address books, password collections, or similar sensitive, private data.</b></p>
 							<p><b>All contents of the repository will be part of the public archive!</b></p>
 						</div>

--- a/templates/reqpage.go
+++ b/templates/reqpage.go
@@ -53,6 +53,16 @@ const RequestPage = `<!DOCTYPE html>
 					<div class="column center">
 						<h1>Welcome to the GIN DOI service <i class="mega-octicon octicon octicon-squirrel"></i></h1>
 					</div>
+
+					{{if HasGitModules GINServerURL .Repository}}
+					<div class="ui negative message" id="gitmodulewarning">
+						<div id="gitmodulebox">
+							<div class="header">Your repository appears to contain git submodules</div>
+							<p><b>Please note that content linked via git submodules will not be included in the published dataset.</b></p>
+						</div>
+					</div>
+					{{end}}
+
 					<div class="ui info message" id="infotable">
 						<div id="infobox">
 							The following <strong>preview</strong> shows the information that will be published in the DOI registry and will be presented permanently alongside the data in your repository.


### PR DESCRIPTION
This pull request
- changes the pre-registration check workflow to collect and display as many request breaking issues as possible. Now there are only three possible fails that are displayed to the user: (Closes issues #96, #101)
  - if the datacite file is missing
  - if the datacite file is not a valid yaml file and cannot be read
  - if the datacite file contains any formal issues: missing values and invalid key entries are now collected and displayed together instead of in individual steps
  - in addition the existence of a license file is always checked and displayed together with other issues to reduce the number of registration fails for a user.
- displays a warning that content linked via git submodules is not included in a published data set. Closes #93.
- adds a secondary round of annex content download since primary download can silently fail on low download rates. Partially addresses #103.
- changes the return to GIN link on the request failure page: the user will now return directly to the request repository page instead to the GIN home page.