### PR TITLE
Fixes and updates

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,8 +1,5 @@
 name: run-tests
 on:
-  # Run build once a month
-  schedule:
-  - cron:  '0 0 1 * *'
   push:
     branches:
       - master

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -162,6 +162,22 @@ func cloneAndZip(repopath string, jobname string, preppath string, targetpath st
 	return zipbasename, zipsize, nil
 }
 
+// getRepoCommit uses a gin client connection to query the latest commit
+// of a provided gin repository and returns either an error or
+// the commit hash as a string.
+func getRepoCommit(client *ginclient.Client, repo string) (string, error) {
+	reqpath := fmt.Sprintf("api/v1/repos/%s/commits/refs/heads/master", repo)
+	resp, err := client.Get(reqpath)
+	if err != nil {
+		return "", fmt.Errorf("failed to get latest commit hash for %q: %s", repo, err.Error())
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read latest commit hash from response for %q: %s", repo, err.Error())
+	}
+	return string(data), nil
+}
+
 // changedirlog logs if a change directory action results in an error;
 // used to log errors when defering directory changes.
 func changedirlog(todir string, lognote string) {

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -88,7 +88,7 @@ func createRegisteredDataset(job *RegistrationJob) error {
 		log.Print("Could not create the metadata template")
 		// XML Creation failed; return with error
 		preperrors = append(preperrors, fmt.Sprintf("Failed to create the XML metadata template: %s", err))
-		mailerr := notifyAdmin(job, preperrors, nil, false)
+		mailerr := notifyAdmin(job, preperrors, nil, false, "")
 		if mailerr != nil {
 			log.Printf("Failed to send notification email: %s", mailerr.Error())
 		}
@@ -100,7 +100,7 @@ func createRegisteredDataset(job *RegistrationJob) error {
 	if err != nil {
 		log.Print("Could not render the metadata file")
 		preperrors = append(preperrors, fmt.Sprintf("Failed to render the XML metadata: %s", err))
-		mailerr := notifyAdmin(job, preperrors, nil, false)
+		mailerr := notifyAdmin(job, preperrors, nil, false, "")
 		if mailerr != nil {
 			log.Printf("Failed to send notification email: %s", mailerr.Error())
 		}
@@ -115,7 +115,7 @@ func createRegisteredDataset(job *RegistrationJob) error {
 	warnings := collectWarnings(job)
 
 	// Send email with either all errors and warnings or preparation success
-	mailerr := notifyAdmin(job, preperrors, warnings, false)
+	mailerr := notifyAdmin(job, preperrors, warnings, false, "")
 	if mailerr != nil {
 		log.Printf("Failed to send notification email: %s", mailerr.Error())
 	}

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -114,13 +114,12 @@ func createRegisteredDataset(job *RegistrationJob) error {
 
 	warnings := collectWarnings(job)
 
-	if len(preperrors)+len(warnings) > 0 {
-		// Resend email with errors if any occurred
-		mailerr := notifyAdmin(job, preperrors, warnings, false)
-		if mailerr != nil {
-			log.Printf("Failed to send notification email: %s", mailerr.Error())
-		}
+	// Send email with either all errors and warnings or preparation success
+	mailerr := notifyAdmin(job, preperrors, warnings, false)
+	if mailerr != nil {
+		log.Printf("Failed to send notification email: %s", mailerr.Error())
 	}
+
 	return err
 }
 

--- a/cmd/gindoid/mail.go
+++ b/cmd/gindoid/mail.go
@@ -95,7 +95,7 @@ func notifyAdmin(job *RegistrationJob, errors, warnings []string, fullinfo bool)
 	// If it is not the initial notification and there are no errors or warnings,
 	// send a notification that the DOI has been prepared without issues.
 	if !fullinfo && len(errors)+len(warnings) == 0 {
-		body = "The repository cloning and zip creation have finished, no issues have been identified\n"
+		body = "Repository cloning and ZIP creation are finished; no issues have been found.\n"
 	}
 
 	body = fmt.Sprintf("%s%s%s", body, errorlist, warninglist)

--- a/cmd/gindoid/mail.go
+++ b/cmd/gindoid/mail.go
@@ -29,7 +29,7 @@ const (
 // sendMail function to send it. Also opens an issue on the XMLRepo if set.
 // If fullinfo is 'false', only errors and warnings are sent in the
 // notification.
-func notifyAdmin(job *RegistrationJob, errors, warnings []string, fullinfo bool) error {
+func notifyAdmin(job *RegistrationJob, errors, warnings []string, fullinfo bool, commithash string) error {
 	urljoin := func(a, b string) string {
 		fallback := fmt.Sprintf("%s/%s (fallback URL join)", a, b)
 		base, err := url.Parse(a)
@@ -54,6 +54,7 @@ func notifyAdmin(job *RegistrationJob, errors, warnings []string, fullinfo bool)
 	xmlurl := fmt.Sprintf("%s/%s/doi.xml", conf.Storage.XMLURL, doi)
 	doitarget := urljoin(conf.Storage.StoreURL, doi)
 	repourl := fmt.Sprintf("%s/%s", GetGINURL(conf), repopath)
+	hashurl := fmt.Sprintf("[%s](%s/commits/master)", commithash, repourl)
 
 	subject := fmt.Sprintf("New DOI registration request: %s", repopath)
 
@@ -71,8 +72,9 @@ func notifyAdmin(job *RegistrationJob, errors, warnings []string, fullinfo bool)
 - Email address: %s
 - DOI XML: %s
 - DOI target URL: %s
+- Latest commit hash: %s
 `
-		body = fmt.Sprintf(infofmt, repopath, repourl, namestr, useremail, xmlurl, doitarget)
+		body = fmt.Sprintf(infofmt, repopath, repourl, namestr, useremail, xmlurl, doitarget, hashurl)
 	}
 
 	errorlist := ""

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -73,34 +73,34 @@ func collectWarnings(job *RegistrationJob) (warnings []string) {
 func authorWarnings(yada *libgin.RepositoryYAML, warnings []string) []string {
 	var orcidRE = regexp.MustCompile(`([[:digit:]]{4}-){3}[[:digit:]]{3}[[:digit:]X]`)
 	var dupID = make(map[string]string)
+	idprefix := map[string]bool{"orcid:": true, "researcherid:": true}
 
 	for idx, auth := range yada.Authors {
 		if auth.ID == "" {
 			continue
 		}
 		lowerID := strings.ToLower(auth.ID)
+		label := fmt.Sprintf("%d (%s)", idx, auth.LastName)
 
 		// Warn when not able to identify ID type
 		if !strings.HasPrefix(lowerID, "orcid") && !strings.HasPrefix(lowerID, "researcherid") {
 			if orcid := orcidRE.Find([]byte(auth.ID)); orcid != nil {
-				warnings = append(warnings, fmt.Sprintf("Author %d (%s) has ORCID-like unspecified ID: %s", idx, auth.LastName, auth.ID))
+				warnings = append(warnings, fmt.Sprintf("Author %s has an ORCID-like unspecified ID: %s", label, auth.ID))
 			} else {
-				warnings = append(warnings, fmt.Sprintf("Author %d (%s) has unknown ID: %s", idx, auth.LastName, auth.ID))
+				warnings = append(warnings, fmt.Sprintf("Author %s has an unknown ID: %s", label, auth.ID))
 			}
 		}
 
 		// Warn on known ID type but missing value
-		idpref := map[string]bool{"orcid:": true, "researcherid:": true}
-		if _, found := idpref[strings.TrimSpace(lowerID)]; found {
-			warnings = append(warnings, fmt.Sprintf("Author %d (%s) has empty ID value: %s", idx, auth.LastName, auth.ID))
+		if _, found := idprefix[strings.TrimSpace(lowerID)]; found {
+			warnings = append(warnings, fmt.Sprintf("Author %s has an empty ID value: %s", label, auth.ID))
 		}
 
 		// Warn on dupliate ID entries
-		if authName, isduplicate := dupID[lowerID]; isduplicate {
-			curr := fmt.Sprintf("%d (%s)", idx, auth.LastName)
-			warnings = append(warnings, fmt.Sprintf("Authors %s and %s have the same ID: %s", authName, curr, auth.ID))
+		if duplabel, isduplicate := dupID[lowerID]; isduplicate {
+			warnings = append(warnings, fmt.Sprintf("Authors %s and %s have the same ID: %s", duplabel, label, auth.ID))
 		} else {
-			dupID[lowerID] = fmt.Sprintf("%d (%s)", idx, auth.LastName)
+			dupID[lowerID] = label
 		}
 	}
 

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -36,6 +36,11 @@ func collectWarnings(job *RegistrationJob) (warnings []string) {
 		}
 	}
 
+	submod := HasGitModules(GetGINURL(job.Config), job.Metadata.SourceRepository)
+	if submod {
+		warnings = append(warnings, fmt.Sprintln("Repository contains submodules"))
+	}
+
 	// Check authors
 	warnings = authorWarnings(job.Metadata.YAMLData, warnings)
 

--- a/cmd/gindoid/validation.go
+++ b/cmd/gindoid/validation.go
@@ -80,6 +80,9 @@ func authorWarnings(yada *libgin.RepositoryYAML, warnings []string) []string {
 	var dupID = make(map[string]string)
 	idprefix := map[string]bool{"orcid:": true, "researcherid:": true}
 
+	orcidURL := "https://pub.orcid.org/v3.0/"
+	researcherURL := "http://publons.com/researcher/"
+
 	for idx, auth := range yada.Authors {
 		if auth.ID == "" {
 			continue
@@ -106,6 +109,19 @@ func authorWarnings(yada *libgin.RepositoryYAML, warnings []string) []string {
 			warnings = append(warnings, fmt.Sprintf("Authors %s and %s have the same ID: %s", duplabel, label, auth.ID))
 		} else {
 			dupID[lowerID] = label
+		}
+
+		// Warn on ID entries not found at the ID service
+		splitIDlist := strings.Split(auth.ID, ":")
+		if len(splitIDlist) == 2 {
+			splitID := strings.TrimSpace(splitIDlist[1])
+
+			invalORCID := strings.HasPrefix(lowerID, "orcid") && !URLexists(fmt.Sprintf("%s%s", orcidURL, splitID))
+			invalResID := strings.HasPrefix(lowerID, "researcherid") && !URLexists(fmt.Sprintf("%s%s", researcherURL, splitID))
+
+			if invalORCID || invalResID {
+				warnings = append(warnings, fmt.Sprintf("Author %s ID was not found at the ID service: %s", label, auth.ID))
+			}
 		}
 	}
 

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -272,7 +272,7 @@ func TestAuthorWarnings(t *testing.T) {
 	if len(checkwarn) != 1 {
 		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)
 	}
-	if !strings.Contains(checkwarn[0], "has ORCID-like unspecified ID") {
+	if !strings.Contains(checkwarn[0], "has an ORCID-like unspecified ID") {
 		t.Fatalf("Expected ORCID like ID message: %v", checkwarn[0])
 	}
 
@@ -282,7 +282,7 @@ func TestAuthorWarnings(t *testing.T) {
 	if len(checkwarn) != 1 {
 		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)
 	}
-	if !strings.Contains(checkwarn[0], "has unknown ID") {
+	if !strings.Contains(checkwarn[0], "has an unknown ID") {
 		t.Fatalf("Expected unknown ID message: %v", checkwarn[0])
 	}
 
@@ -292,7 +292,7 @@ func TestAuthorWarnings(t *testing.T) {
 	if len(checkwarn) != 1 {
 		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)
 	}
-	if !strings.Contains(checkwarn[0], "has empty ID value") {
+	if !strings.Contains(checkwarn[0], "has an empty ID value") {
 		t.Fatalf("Expected empty ORCID value message: %v", checkwarn[0])
 	}
 
@@ -301,16 +301,16 @@ func TestAuthorWarnings(t *testing.T) {
 	if len(checkwarn) != 1 {
 		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)
 	}
-	if !strings.Contains(checkwarn[0], "has empty ID value") {
+	if !strings.Contains(checkwarn[0], "has an empty ID value") {
 		t.Fatalf("Expected empty researcherid value message: %v", checkwarn[0])
 	}
 
 	// Check warning on duplicate ORCID, researchID, unidentifyable ID
-	yada.Authors[0].ID = "orcid:0000-0000-0000-000x"
+	yada.Authors[0].ID = "orcid:0000-0001-6744-1159"
 	auth = yada.Authors
-	auth = append(auth, libgin.Author{ID: "researcherid:a-0000-0000"})
-	auth = append(auth, libgin.Author{ID: "ORCID:0000-0000-0000-000X"})
-	auth = append(auth, libgin.Author{ID: "researcherID:A-0000-0000"})
+	auth = append(auth, libgin.Author{ID: "researcherid:k-3714-2014"})
+	auth = append(auth, libgin.Author{ID: "ORCID:0000-0001-6744-1159"})
+	auth = append(auth, libgin.Author{ID: "researcherID:K-3714-2014"})
 	yada.Authors = auth
 
 	checkwarn = authorWarnings(yada, warnings)
@@ -324,8 +324,10 @@ func TestAuthorWarnings(t *testing.T) {
 	}
 
 	// Check no warning on valid entries
-	yada.Authors[2].ID = "orcid:1111-1111-1111-1111"
-	yada.Authors[3].ID = "researcherid:A-1111-1111"
+	var cleanauth []libgin.Author
+	cleanauth = append(cleanauth, libgin.Author{ID: "researcherid:k-3714-2014"})
+	cleanauth = append(cleanauth, libgin.Author{ID: "ORCID:0000-0001-6744-1159"})
+	yada.Authors = cleanauth
 	checkwarn = authorWarnings(yada, warnings)
 	if len(checkwarn) != 0 {
 		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -305,7 +305,25 @@ func TestAuthorWarnings(t *testing.T) {
 		t.Fatalf("Expected empty researcherid value message: %v", checkwarn[0])
 	}
 
-	// Check warning on duplicate ORCID, researchID, unidentifyable ID
+	// Check warning on false author ID entries
+	yada.Authors[0].ID = "orcid:x000-0001-2345-6789"
+	checkwarn = authorWarnings(yada, warnings)
+	if len(checkwarn) != 1 {
+		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)
+	}
+	if !strings.Contains(checkwarn[0], "ID was not found at the ID service") {
+		t.Fatalf("Expected not found ID message: %v", checkwarn[0])
+	}
+	yada.Authors[0].ID = "researcherID:x-1234-5678"
+	checkwarn = authorWarnings(yada, warnings)
+	if len(checkwarn) != 1 {
+		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)
+	}
+	if !strings.Contains(checkwarn[0], "ID was not found at the ID service") {
+		t.Fatalf("Expected not found ID message: %v", checkwarn[0])
+	}
+
+	// Check warning on duplicate ORCID, researchID
 	yada.Authors[0].ID = "orcid:0000-0001-6744-1159"
 	auth = yada.Authors
 	auth = append(auth, libgin.Author{ID: "researcherid:k-3714-2014"})


### PR DESCRIPTION
This PR fixes some issues and adds the following updates:
- directory switching for cloning and zip creation has been refactored: now the server always switches back to the root directory after cloning or zip creation. This should fix #104.
- a notification email is sent to the server admins when the clone and zip process has successfully finished and no metadata issues have been identified. This closes #106.
- the metadata warning list to the server admins has been expanded. It now contains a warning, 
  - if the repository contains submodules; this closes #92
  - if an author ID cannot be verified with the corresponding ID service (orcid or researchID); this includes the datacite.yml author ID  template entries; this closes #107.
- when creating the initial DOI request issue on gin and sending the first email to the server admins, the information now also contains the latest commit hash of the requesting Gin repository to enable identification of any commits added after the DOI request. This closes #91.
- removed scheduled builds from the gh actions matrix since inactivity for > 4 months seems to deactivate gh actions alltogether (also for pushes and pull requests).