### PR TITLE
Create dataset listing page

### DIFF
--- a/cmd/gindoid/genindex.go
+++ b/cmd/gindoid/genindex.go
@@ -58,7 +58,7 @@ func (d doilist) Swap(i, j int) {
 func mkindex(cmd *cobra.Command, args []string) {
 	fmt.Printf("Generating %d pages\n", len(args))
 
-	var curritems []doiitem
+	var dois []doiitem
 	for idx, filearg := range args {
 		fmt.Printf("%3d: %s\n", idx, filearg)
 		var contents []byte
@@ -107,7 +107,7 @@ func mkindex(cmd *cobra.Command, args []string) {
 			Authors:   strings.Join(authors, ", "),
 			Isodate:   metadata.Dates[0].Value,
 		}
-		curritems = append(curritems, curr)
+		dois = append(dois, curr)
 	}
 
 	fname := "index.html"
@@ -125,8 +125,8 @@ func mkindex(cmd *cobra.Command, args []string) {
 	defer fp.Close()
 
 	// sorting the list of items by 1) date descending and 2) title ascending
-	sort.Sort(doilist(curritems))
-	if err := tmpl.Execute(fp, curritems); err != nil {
+	sort.Sort(doilist(dois))
+	if err := tmpl.Execute(fp, dois); err != nil {
 		fmt.Printf("Error rendering the landing page: %s", err.Error())
 		return
 	}

--- a/cmd/gindoid/genindex.go
+++ b/cmd/gindoid/genindex.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/G-Node/libgin/libgin"
+	"github.com/spf13/cobra"
+)
+
+// DOIItem provides basic DOI information required to
+// render the root index page.``
+type DOIItem struct {
+	Title     string
+	Authors   string
+	Isodate   string
+	Shorthash string
+}
+
+// mkhtml reads the provided XML files or URLs and generates the HTML landing
+// page for each.
+func mkindex(cmd *cobra.Command, args []string) {
+	fmt.Printf("Generating %d pages\n", len(args))
+
+	var curritems []DOIItem
+	for idx, filearg := range args {
+		fmt.Printf("%3d: %s\n", idx, filearg)
+		var contents []byte
+		var err error
+		if isURL(filearg) {
+			contents, err = readFileAtURL(filearg)
+		} else {
+			contents, err = readFileAtPath(filearg)
+		}
+		if err != nil {
+			fmt.Printf("Failed to read file at %q: %s\n", filearg, err.Error())
+			continue
+		}
+
+		datacite := new(libgin.DataCite)
+		err = xml.Unmarshal(contents, datacite)
+		if err != nil {
+			fmt.Printf("Failed to unmarshal contents of %q: %s\n", filearg, err.Error())
+			continue
+		}
+		metadata := &libgin.RepositoryMetadata{
+			DataCite: datacite,
+		}
+
+		authors := make([]string, len(metadata.Creators))
+		for idx, author := range metadata.Creators {
+			namesplit := strings.SplitN(author.Name, ",", 2) // Author names are LastName, FirstName
+			if len(namesplit) != 2 {
+				// No comma: Bad input, mononym, or empty field.
+				// Trim, add continue.
+				authors[idx] = strings.TrimSpace(author.Name)
+				continue
+			}
+			// render as LastName Initials, ...
+			firstnames := strings.Fields(namesplit[1])
+			var initials string
+			for _, name := range firstnames {
+				initials += string(name[0])
+			}
+			authors[idx] = fmt.Sprintf("%s %s", strings.TrimSpace(namesplit[0]), initials)
+		}
+
+		curr := DOIItem{
+			Title:     metadata.Titles[0],
+			Shorthash: metadata.Identifier.ID,
+			Authors:   strings.Join(authors, ", "),
+			Isodate:   metadata.Dates[0].Value,
+		}
+		curritems = append(curritems, curr)
+	}
+
+	fname := "index.html"
+	tmpl, err := prepareTemplates("IndexPage")
+	if err != nil {
+		fmt.Printf("Error preparing template: %s", err.Error())
+		return
+	}
+
+	fp, err := os.Create(fname)
+	if err != nil {
+		fmt.Printf("Could not create the landing page file: %s", err.Error())
+		return
+	}
+	defer fp.Close()
+	if err := tmpl.Execute(fp, curritems); err != nil {
+		fmt.Printf("Error rendering the landing page: %s", err.Error())
+		return
+	}
+}

--- a/cmd/gindoid/genindex_test.go
+++ b/cmd/gindoid/genindex_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestDoilist(t *testing.T) {
+	titlefirst := "Pickman's Model"
+	titlesecond := "The Doom that Came to Sarnath"
+	titlethird := "The Statement of Randolph Carter"
+
+	// test sort by date descending
+	dois := []doiitem{
+		{
+			Title:   titlethird,
+			Isodate: "1919-12-03",
+		},
+		{
+			Title:   titlefirst,
+			Isodate: "1926-09-01",
+		},
+	}
+
+	if dois[0].Title != titlethird {
+		t.Fatalf("Fail setting up doilist, wrong item order: %v", dois)
+	}
+
+	sort.Sort(doilist(dois))
+	if dois[0].Title != titlefirst {
+		t.Fatalf("Failed sorting by Isodate: %v", dois)
+	}
+
+	// test secondary sort by title when dates are identical
+	dois = append(dois,
+		doiitem{
+			Title:   titlesecond,
+			Isodate: "1919-12-03",
+		})
+
+	sort.Sort(doilist(dois))
+	if dois[1].Title != titlesecond {
+		t.Fatalf("Failed secondary sorting by Title: %v", dois)
+	}
+}

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -25,7 +25,7 @@ func setUpCommands(verstr string) *cobra.Command {
 		Version:               fmt.Sprintln(verstr),
 		DisableFlagsInUseLine: true,
 	}
-	cmds := make([]*cobra.Command, 5)
+	cmds := make([]*cobra.Command, 6)
 	cmds[0] = &cobra.Command{
 		Use:                   "start",
 		Short:                 "Start the GIN DOI service",
@@ -74,6 +74,17 @@ Previously generated pages are overwritten, so this command only makes sense if 
 The command accepts GIN repositories of format "GIN:owner/repository", yaml file paths and URLs to yaml files (mixing allowed) and will generate one XML file for each YAML file found. If the page generation requires information that is missing from the XML file (e.g., archive file size, repository URLs), the program will attempt to retrieve the metadata by querying the online resources. If that fails, a warning is printed and the file is still generated with the available information. Contextual information like size or date have to be added manually.`,
 		Args:                  cobra.MinimumNArgs(1),
 		Run:                   mkxml,
+		Version:               verstr,
+		DisableFlagsInUseLine: true,
+	}
+	cmds[5] = &cobra.Command{
+		Use:   "make-index <xml file>...",
+		Short: "Generate the index.html file from one or more DataCite XML files",
+		Long: `Generate the index.html file from one or more DataCite XML files.
+
+The command accepts file paths and URLs (mixing allowed) and will generate one index HTML page containing the information of all XML files found.`,
+		Args:                  cobra.MinimumNArgs(1),
+		Run:                   mkindex,
 		Version:               verstr,
 		DisableFlagsInUseLine: true,
 	}

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -186,6 +186,7 @@ var templateMap = map[string]string{
 	"LandingPage":        gdtmpl.LandingPage,
 	"KeywordIndex":       gdtmpl.KeywordIndex,
 	"Keyword":            gdtmpl.Keyword,
+	"IndexPage":          gdtmpl.IndexPage,
 }
 
 // prepareTemplates initialises and parses a sequence of templates in the order

--- a/templates/common.go
+++ b/templates/common.go
@@ -25,7 +25,7 @@ const Footer = `
 		<footer>
 			<div class="ui container">
 				<div class="ui center links item brand footertext">
-					<a href="http://www.g-node.org"><img class="ui mini footericon" src="https://projects.g-node.org/assets/gnode-bootstrap-theme/1.2.0-snapshot/img/gnode-icon-50x50-transparent.png"/>© G-Node, 2016-2021</a>
+					<a href="http://www.g-node.org"><img class="ui mini footericon" src="https://projects.g-node.org/assets/gnode-bootstrap-theme/1.2.0-snapshot/img/gnode-icon-50x50-transparent.png"/>© G-Node, 2016-2022</a>
 					<a href="https://gin.g-node.org/G-Node/Info/wiki/about">About</a>
 					<a href="https://gin.g-node.org/G-Node/Info/wiki/imprint">Imprint</a>
 					<a href="https://gin.g-node.org/G-Node/Info/wiki/contact">Contact</a>

--- a/templates/index.go
+++ b/templates/index.go
@@ -17,7 +17,7 @@ const IndexPage = `<!DOCTYPE html>
 		<title>G-Node Open Data</title>
 	</head>
 	<body>
-		{{template "Nav"}}
+		{{ template "Nav" }}
 		<div class="ui stackable middle very relaxed page grid">
 			<div class="sixteenn wide center aligned centered column">
 				<h1>G-Node Open Data</h1>
@@ -31,7 +31,6 @@ const IndexPage = `<!DOCTYPE html>
 						</tr>
 					</thead>
 					<tbody>
-
 						{{ range . }}
 							<tr>
 								<td><a href="https://doi.org/{{ .Shorthash }}">{{ .Title }}</a>
@@ -45,6 +44,6 @@ const IndexPage = `<!DOCTYPE html>
 				More public datasets can be found at <a href="https://gin.g-node.org">gin.g-node.org</a>
 			</div>
 		</div>
-		{{template "Footer"}}
+		{{ template "Footer" }}
 	</body>
 </html>`

--- a/templates/index.go
+++ b/templates/index.go
@@ -1,0 +1,50 @@
+package gdtmpl
+
+// IndexPage is the template for rendering the index page of registered datasets.
+const IndexPage = `<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=edge">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<link rel="shortcut icon" href="/assets/img/favicon.png">
+		<link rel="stylesheet" href="/assets/css/semantic-2.3.1.min.css">
+		<link rel="stylesheet" href="/assets/octicons-4.3.0/octicons.min.css">
+		<link rel="stylesheet" href="/assets/css/gogs.css">
+		<link rel="stylesheet" href="/assets/css/custom.css">
+
+		<title>G-Node Open Data</title>
+	</head>
+	<body>
+		{{template "Nav"}}
+		<div class="ui stackable middle very relaxed page grid">
+			<div class="sixteenn wide center aligned centered column">
+				<h1>G-Node Open Data</h1>
+				<p><b>Registered Datasets</b></p>
+				<table class="ui very basic table">
+					<thead>
+						<tr>
+							<th class="ten wide">Title</th>
+							<th class="two wide">Date</th>
+							<th class="four wide">DOI</th>
+						</tr>
+					</thead>
+					<tbody>
+
+						{{ range . }}
+							<tr>
+								<td><a href="https://doi.org/{{ .Shorthash }}">{{ .Title }}</a>
+								<br>{{ .Authors }}</td>
+								<td>{{ .Isodate }}</td>
+								<td><a href="https://doi.org/{{ .Shorthash }}" class ="ui grey label">{{ .Shorthash }}</a></td>
+							</tr>
+						{{end}}
+					</tbody>
+				</table>
+				More public datasets can be found at <a href="https://gin.g-node.org">gin.g-node.org</a>
+			</div>
+		</div>
+		{{template "Footer"}}
+	</body>
+</html>`


### PR DESCRIPTION
This PR adds the command line option `make-index` to generate the dataset listing page file as 'index.html' from one or more DataCite XML files.

Closes #48.