### PR TITLE
"Generate URLs" and "Generate all" CLI options

### DIFF
--- a/cmd/gindoid/genall.go
+++ b/cmd/gindoid/genall.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// mkall calls all functions creating doi specific files
+// from provided XML files or URLs.
+func mkall(cmd *cobra.Command, args []string) {
+	// generate root landing page file
+	mkindex(cmd, args)
+	// generate sitemap file
+	mksitemap(cmd, args)
+	// generate keyword pages
+	mkkeywords(cmd, args)
+	// generate html dataset landing pages
+	mkhtml(cmd, args)
+}

--- a/cmd/gindoid/gensitemap.go
+++ b/cmd/gindoid/gensitemap.go
@@ -44,7 +44,7 @@ func (d urllist) Swap(i, j int) {
 
 // mksitemap reads the provided XML files or URLs and generates a
 // google sitemap 'urls.txt' files containing the corresponding DOI URLs.
-func mksitemap(args []string) {
+func mksitemap(cmd *cobra.Command, args []string) {
 	fmt.Printf("Parsing %d files\n", len(args))
 
 	var urls []doiitem
@@ -94,11 +94,4 @@ func mksitemap(args []string) {
 	if err != nil {
 		fmt.Printf("Error writing sitemap file: %s", err.Error())
 	}
-}
-
-// runmksitemap is a wrapper for the mksitemap function to
-// enable import of mksitemap by other functions
-// keeping the distinct command line function available.
-func runmksitemap(cmd *cobra.Command, args []string) {
-	mksitemap(args)
 }

--- a/cmd/gindoid/gensitemap.go
+++ b/cmd/gindoid/gensitemap.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/G-Node/libgin/libgin"
+	"github.com/spf13/cobra"
+)
+
+// mksitemap reads the provided XML files or URLs and generates a
+// google sitemap 'urls.txt' files with the corresponding links.
+func mksitemap(cmd *cobra.Command, args []string) {
+	fmt.Printf("Parsing %d files\n", len(args))
+
+	var siteurls string
+	for idx, filearg := range args {
+		fmt.Printf("%3d: %s\n", idx, filearg)
+		var contents []byte
+		var err error
+		if isURL(filearg) {
+			contents, err = readFileAtURL(filearg)
+		} else {
+			contents, err = readFileAtPath(filearg)
+		}
+		if err != nil {
+			fmt.Printf("Failed to read file at %q: %s\n", filearg, err.Error())
+			continue
+		}
+
+		datacite := new(libgin.DataCite)
+		err = xml.Unmarshal(contents, datacite)
+		if err != nil {
+			fmt.Printf("Failed to unmarshal contents of %q: %s\n", filearg, err.Error())
+			continue
+		}
+		metadata := &libgin.RepositoryMetadata{
+			DataCite: datacite,
+		}
+
+		siteurls += fmt.Sprintf("https://doi.gin.g-node.org/%s/\n", metadata.Identifier.ID)
+	}
+
+	fname := "urls.txt"
+	err := ioutil.WriteFile(fname, []byte(siteurls), 0664)
+	if err != nil {
+		fmt.Printf("Error writing sitemap file: %s", err.Error())
+	}
+}

--- a/cmd/gindoid/gensitemap.go
+++ b/cmd/gindoid/gensitemap.go
@@ -11,24 +11,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// urlitem provides basic DOI information required to
-// sort a list of url items.
-type urlitem struct {
-	Title     string
-	Isodate   string
-	Shorthash string
-}
-
 // urllist is an implementation of the sort interface to
-// sort a list of urlitems ascending by date and title.
-type urllist []urlitem
+// sort a list of doiitems ascending by date and title.
+type urllist []doiitem
 
 func (d urllist) Len() int {
 	return len(d)
 }
 
-// Less of the doilist implementation should provide the means
-// to sort a list of doiitems first by Isodate in descending
+// Less of the urllist implementation should provide the means
+// to sort a list of doiitems first by Isodate in ascending
 // and in case of identical dates by Title in ascending order.
 func (d urllist) Less(i, j int) bool {
 	idate, err := time.Parse("2006-01-02", d[i].Isodate)
@@ -51,11 +43,11 @@ func (d urllist) Swap(i, j int) {
 }
 
 // mksitemap reads the provided XML files or URLs and generates a
-// google sitemap 'urls.txt' files with the corresponding links.
+// google sitemap 'urls.txt' files containing the corresponding DOI URLs.
 func mksitemap(args []string) {
 	fmt.Printf("Parsing %d files\n", len(args))
 
-	var urls []urlitem
+	var urls []doiitem
 	for idx, filearg := range args {
 		fmt.Printf("%3d: %s\n", idx, filearg)
 		var contents []byte
@@ -81,7 +73,7 @@ func mksitemap(args []string) {
 		}
 
 		// required to sort list
-		curr := urlitem{
+		curr := doiitem{
 			Title:     metadata.Titles[0],
 			Shorthash: metadata.Identifier.ID,
 			Isodate:   metadata.Dates[0].Value,
@@ -106,7 +98,7 @@ func mksitemap(args []string) {
 
 // runmksitemap is a wrapper for the mksitemap function to
 // enable import of mksitemap by other functions
-// but keep the distinct command line function available.
+// keeping the distinct command line function available.
 func runmksitemap(cmd *cobra.Command, args []string) {
 	mksitemap(args)
 }

--- a/cmd/gindoid/gensitemap.go
+++ b/cmd/gindoid/gensitemap.go
@@ -52,7 +52,7 @@ func (d urllist) Swap(i, j int) {
 
 // mksitemap reads the provided XML files or URLs and generates a
 // google sitemap 'urls.txt' files with the corresponding links.
-func mksitemap(cmd *cobra.Command, args []string) {
+func mksitemap(args []string) {
 	fmt.Printf("Parsing %d files\n", len(args))
 
 	var urls []urlitem
@@ -88,6 +88,7 @@ func mksitemap(cmd *cobra.Command, args []string) {
 		}
 		urls = append(urls, curr)
 	}
+
 	// sort by date and title ascending
 	sort.Sort(urllist(urls))
 
@@ -101,4 +102,11 @@ func mksitemap(cmd *cobra.Command, args []string) {
 	if err != nil {
 		fmt.Printf("Error writing sitemap file: %s", err.Error())
 	}
+}
+
+// runmksitemap is a wrapper for the mksitemap function to
+// enable import of mksitemap by other functions
+// but keep the distinct command line function available.
+func runmksitemap(cmd *cobra.Command, args []string) {
+	mksitemap(args)
 }

--- a/cmd/gindoid/gensitemap_test.go
+++ b/cmd/gindoid/gensitemap_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestURLlist(t *testing.T) {
+	titlefirst := "The Doom that Came to Sarnath"
+	titlesecond := "The Statement of Randolph Carter"
+	titlethird := "Pickman's Model"
+
+	// test sort by date ascending
+	dois := []urlitem{
+		{
+			Title:   titlethird,
+			Isodate: "1926-09-01",
+		},
+		{
+			Title:   titlefirst,
+			Isodate: "1919-12-03",
+		},
+	}
+
+	if dois[0].Title != titlethird {
+		t.Fatalf("Fail setting up doilist, wrong item order: %v", dois)
+	}
+
+	sort.Sort(urllist(dois))
+	if dois[0].Title != titlefirst {
+		t.Fatalf("Failed sorting by Isodate: %v", dois)
+	}
+
+	// test secondary sort by title when dates are identical
+	dois = append(dois,
+		urlitem{
+			Title:   titlesecond,
+			Isodate: "1919-12-03",
+		})
+
+	sort.Sort(urllist(dois))
+	if dois[0].Title != titlefirst || dois[1].Title != titlesecond {
+		t.Fatalf("Failed secondary sorting by Title: %v", dois)
+	}
+}

--- a/cmd/gindoid/gensitemap_test.go
+++ b/cmd/gindoid/gensitemap_test.go
@@ -11,7 +11,7 @@ func TestURLlist(t *testing.T) {
 	titlethird := "Pickman's Model"
 
 	// test sort by date ascending
-	dois := []urlitem{
+	dois := []doiitem{
 		{
 			Title:   titlethird,
 			Isodate: "1926-09-01",
@@ -33,7 +33,7 @@ func TestURLlist(t *testing.T) {
 
 	// test secondary sort by title when dates are identical
 	dois = append(dois,
-		urlitem{
+		doiitem{
 			Title:   titlesecond,
 			Isodate: "1919-12-03",
 		})

--- a/cmd/gindoid/keywords.go
+++ b/cmd/gindoid/keywords.go
@@ -12,7 +12,9 @@ import (
 )
 
 func mkkeywords(cmd *cobra.Command, args []string) {
-	keywordMap := make(map[string][]*libgin.RepositoryMetadata) // map keywords to DOIs
+	// map keywords to DOIs
+	keywordMap := make(map[string][]*libgin.RepositoryMetadata)
+
 	fmt.Println("Reading files")
 	for idx, filearg := range args {
 		var contents []byte
@@ -54,13 +56,14 @@ func mkkeywords(cmd *cobra.Command, args []string) {
 		if err != nil {
 			continue
 		}
-		err = os.MkdirAll(kw, 0777)
+		// use a "keywords" root directory
+		err = os.MkdirAll(fmt.Sprintf("keywords/%s", kw), 0777)
 		if err != nil {
 			log.Printf("Could not create the keyword page dir: %s", err.Error())
 			continue
 		}
 
-		fp, err := os.Create(fmt.Sprintf("%s/index.html", kw))
+		fp, err := os.Create(fmt.Sprintf("keywords/%s/index.html", kw))
 		if err != nil {
 			log.Printf("Could not create the keyword page file: %s", err.Error())
 			continue
@@ -104,9 +107,9 @@ func mkkeywords(cmd *cobra.Command, args []string) {
 	if err != nil {
 		return
 	}
-	fp, err := os.Create("index.html")
+	fp, err := os.Create("keywords/index.html")
 	if err != nil {
-		log.Printf("Could not create the keyword page file: %s", err.Error())
+		log.Printf("Could not create the keyword list page file: %s", err.Error())
 		return
 	}
 	defer fp.Close()

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -95,7 +95,7 @@ The command accepts file paths and URLs (mixing allowed) and will generate one i
 
 The command accepts file paths and URLs (mixing allowed) and will generate one index HTML page containing the information of all XML files found.`,
 		Args:                  cobra.MinimumNArgs(1),
-		Run:                   mksitemap,
+		Run:                   runmksitemap,
 		Version:               verstr,
 		DisableFlagsInUseLine: true,
 	}

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -25,7 +25,7 @@ func setUpCommands(verstr string) *cobra.Command {
 		Version:               fmt.Sprintln(verstr),
 		DisableFlagsInUseLine: true,
 	}
-	cmds := make([]*cobra.Command, 7)
+	cmds := make([]*cobra.Command, 8)
 	cmds[0] = &cobra.Command{
 		Use:                   "start",
 		Short:                 "Start the GIN DOI service",
@@ -99,6 +99,20 @@ The command accepts file paths and URLs (mixing allowed) and will generate one i
 		Version:               verstr,
 		DisableFlagsInUseLine: true,
 	}
+	cmds[7] = &cobra.Command{
+		Use:   "make-all <xml file>...",
+		Short: "Generate all html files and the google sitemap file.",
+		Long: `Generate all html files and the google sitemap file.
+
+The command accepts file paths and URLs (mixing allowed) of DOI XML files 
+and will generate the root landing HTML page, the google sitemap urls.txt file, 
+the keywords html pages and all DOI html landing pages from the XML files.`,
+		Args:                  cobra.MinimumNArgs(1),
+		Run:                   mkall,
+		Version:               verstr,
+		DisableFlagsInUseLine: true,
+	}
+
 	rootCmd.AddCommand(cmds...)
 	return rootCmd
 }

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -95,11 +95,10 @@ The command accepts file paths and URLs (mixing allowed) and will generate one i
 
 The command accepts file paths and URLs (mixing allowed) and will generate one index HTML page containing the information of all XML files found.`,
 		Args:                  cobra.MinimumNArgs(1),
-		Run:                   runmksitemap,
+		Run:                   mksitemap,
 		Version:               verstr,
 		DisableFlagsInUseLine: true,
 	}
-
 	rootCmd.AddCommand(cmds...)
 	return rootCmd
 }

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -25,7 +25,7 @@ func setUpCommands(verstr string) *cobra.Command {
 		Version:               fmt.Sprintln(verstr),
 		DisableFlagsInUseLine: true,
 	}
-	cmds := make([]*cobra.Command, 6)
+	cmds := make([]*cobra.Command, 7)
 	cmds[0] = &cobra.Command{
 		Use:                   "start",
 		Short:                 "Start the GIN DOI service",
@@ -85,6 +85,17 @@ The command accepts GIN repositories of format "GIN:owner/repository", yaml file
 The command accepts file paths and URLs (mixing allowed) and will generate one index HTML page containing the information of all XML files found.`,
 		Args:                  cobra.MinimumNArgs(1),
 		Run:                   mkindex,
+		Version:               verstr,
+		DisableFlagsInUseLine: true,
+	}
+	cmds[6] = &cobra.Command{
+		Use:   "make-sitemap <xml file>...",
+		Short: "Generate the urls.txt google sitemap file from one or more DataCite XML files",
+		Long: `Generate the urls.txt google sitemap file from one or more DataCite XML files.
+
+The command accepts file paths and URLs (mixing allowed) and will generate one index HTML page containing the information of all XML files found.`,
+		Args:                  cobra.MinimumNArgs(1),
+		Run:                   mksitemap,
 		Version:               verstr,
 		DisableFlagsInUseLine: true,
 	}


### PR DESCRIPTION
This PR adds two command line options to the server executable
- `make-sitemap` generates the `urls.txt` google sitemap file from one or more DataCite XML files. Closes #109.
- `make-all` generates all html files (dataset listing page, keywords pages, landing pages) and the google sitemap file from one or more DataCite XML files. Closes #110 and #111.
