### PR TITLE
Test CLI page creation options

### DIFF
--- a/cmd/gindoid/genall.go
+++ b/cmd/gindoid/genall.go
@@ -14,5 +14,5 @@ func mkall(cmd *cobra.Command, args []string) {
 	// generate keyword pages
 	clikeywords(cmd, args)
 	// generate html dataset landing pages
-	mkhtml(cmd, args)
+	clihtml(cmd, args)
 }

--- a/cmd/gindoid/genall.go
+++ b/cmd/gindoid/genall.go
@@ -12,7 +12,7 @@ func mkall(cmd *cobra.Command, args []string) {
 	// generate sitemap file
 	clisitemap(cmd, args)
 	// generate keyword pages
-	mkkeywords(cmd, args)
+	clikeywords(cmd, args)
 	// generate html dataset landing pages
 	mkhtml(cmd, args)
 }

--- a/cmd/gindoid/genall.go
+++ b/cmd/gindoid/genall.go
@@ -8,7 +8,7 @@ import (
 // from provided XML files or URLs.
 func mkall(cmd *cobra.Command, args []string) {
 	// generate root landing page file
-	mkindex(cmd, args)
+	cliindex(cmd, args)
 	// generate sitemap file
 	clisitemap(cmd, args)
 	// generate keyword pages

--- a/cmd/gindoid/genall.go
+++ b/cmd/gindoid/genall.go
@@ -10,7 +10,7 @@ func mkall(cmd *cobra.Command, args []string) {
 	// generate root landing page file
 	mkindex(cmd, args)
 	// generate sitemap file
-	mksitemap(cmd, args)
+	clisitemap(cmd, args)
 	// generate keyword pages
 	mkkeywords(cmd, args)
 	// generate html dataset landing pages

--- a/cmd/gindoid/genall_test.go
+++ b/cmd/gindoid/genall_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"testing"
+)
+
+func TestMKall(t *testing.T) {
+	// setup temp directory
+	targetpath, err := ioutil.TempDir("", "test_cli_all")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(targetpath)
+
+	clioption := "make-all"
+	cmd := setUpCommands("")
+
+	// only check the CLI option with one valid file,
+	// the detailled tests should be handled via testing
+	// the subcommands.
+
+	// create local test file server
+	server := serveDataciteServer()
+	defer server.Close()
+
+	// check local test server works
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Could not parse server URL: %q", serverURL)
+	}
+
+	// test no error on valid file
+	testValidXML := fmt.Sprintf("%s/xml", server.URL)
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testValidXML})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on valid file: %s", err.Error())
+	}
+	fi, err := ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) == 0 {
+		t.Fatal("Found no output files on valid input")
+	}
+}

--- a/cmd/gindoid/genhtml.go
+++ b/cmd/gindoid/genhtml.go
@@ -39,6 +39,17 @@ func mkhtml(cmd *cobra.Command, args []string) {
 			DataCite: datacite,
 		}
 
+		// check missing titles and rightslist; initialize empty
+		// and notify without failing to avoid broken html files.
+		if len(metadata.Titles) < 1 {
+			metadata.Titles = []string{""}
+			fmt.Printf("Warning: no titles found in file %q\n", filearg)
+		}
+		if len(metadata.RightsList) < 1 {
+			metadata.RightsList = []libgin.Rights{{Name: "", URL: ""}}
+			fmt.Printf("Warning: no Rights found in file %q\n", filearg)
+		}
+
 		// find URLs in RelatedIdentifiers
 		for _, relid := range metadata.RelatedIdentifiers {
 			switch u := strings.ToLower(relid.Identifier); {

--- a/cmd/gindoid/genhtml_test.go
+++ b/cmd/gindoid/genhtml_test.go
@@ -43,7 +43,7 @@ func TestMKhtml(t *testing.T) {
 	}
 
 	// create local test XML file server
-	server := serveDataciteXMLserver()
+	server := serveDataciteServer()
 	defer server.Close()
 
 	// check local test server works

--- a/cmd/gindoid/genindex.go
+++ b/cmd/gindoid/genindex.go
@@ -91,6 +91,11 @@ func mkindex(cmd *cobra.Command, args []string) {
 		dois = append(dois, curr)
 	}
 
+	if len(dois) < 1 {
+		log.Printf("No DOIs parsed, skipping empty 'index' file creation.")
+		return
+	}
+
 	fname := "index.html"
 	tmpl, err := prepareTemplates("IndexPage")
 	if err != nil {

--- a/cmd/gindoid/genindex.go
+++ b/cmd/gindoid/genindex.go
@@ -85,6 +85,15 @@ func mkindex(xmlFiles []string, outpath string) {
 			DataCite: datacite,
 		}
 
+		if len(metadata.Titles) < 1 {
+			log.Printf("Could not parse DOI title, skipping '%s'\n", filearg)
+			continue
+		}
+		if len(metadata.Dates) < 1 {
+			log.Printf("Could not parse DOI date issued, skipping '%s'\n", filearg)
+			continue
+		}
+
 		curr := doiitem{
 			Title:     metadata.Titles[0],
 			Shorthash: metadata.Identifier.ID,

--- a/cmd/gindoid/genindex.go
+++ b/cmd/gindoid/genindex.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 	"time"
 
@@ -52,13 +53,15 @@ func (d doilist) Swap(i, j int) {
 	d[i], d[j] = d[j], d[i]
 }
 
-// mkindex reads the provided XML files or URLs and generates the HTML landing
-// page for each.
-func mkindex(cmd *cobra.Command, args []string) {
-	log.Printf("Parsing %d files\n", len(args))
+// mkindex reads the provided XML files or URLs and generates
+// the HTML list index page with the parsed information.
+// If an outpath is provided, the file will be created there;
+// default is the current working directory.
+func mkindex(xmlFiles []string, outpath string) {
+	log.Printf("Parsing %d files\n", len(xmlFiles))
 
 	var dois []doiitem
-	for idx, filearg := range args {
+	for idx, filearg := range xmlFiles {
 		log.Printf("%3d: %s\n", idx, filearg)
 		var contents []byte
 		var err error
@@ -96,13 +99,16 @@ func mkindex(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	fname := "index.html"
 	tmpl, err := prepareTemplates("IndexPage")
 	if err != nil {
 		log.Printf("Error preparing template: %s", err.Error())
 		return
 	}
 
+	fname := "index.html"
+	if outpath != "" {
+		fname = filepath.Join(outpath, fname)
+	}
 	fp, err := os.Create(fname)
 	if err != nil {
 		log.Printf("Could not create the landing page file: %s", err.Error())
@@ -116,4 +122,21 @@ func mkindex(cmd *cobra.Command, args []string) {
 		log.Printf("Error rendering the landing page: %s", err.Error())
 		return
 	}
+}
+
+// cliindex handles command line arguments and passes them
+// to the mkindex function.
+// An optional output file path can be passed via the command
+// line arguments; default output path is the current working directory.
+func cliindex(cmd *cobra.Command, args []string) {
+	var outpath string
+	oval, err := cmd.Flags().GetString("out")
+	if err != nil {
+		log.Printf("-- Error parsing output directory flag: %s\n", err.Error())
+	} else if oval != "" {
+		outpath = oval
+		log.Printf("-- Using output directory '%s'\n", outpath)
+	}
+
+	mkindex(args, outpath)
 }

--- a/cmd/gindoid/genindex.go
+++ b/cmd/gindoid/genindex.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"encoding/xml"
-	"fmt"
+	"log"
 	"os"
 	"sort"
 	"time"
@@ -35,11 +35,11 @@ func (d doilist) Len() int {
 func (d doilist) Less(i, j int) bool {
 	idate, err := time.Parse("2006-01-02", d[i].Isodate)
 	if err != nil {
-		fmt.Printf("Error parsing date '%s' of item '%s'", d[i].Isodate, d[i].Title)
+		log.Printf("Error parsing date '%s' of item '%s'", d[i].Isodate, d[i].Title)
 	}
 	jdate, err := time.Parse("2006-01-02", d[j].Isodate)
 	if err != nil {
-		fmt.Printf("Error parsing date '%s' of item '%s'", d[j].Isodate, d[j].Title)
+		log.Printf("Error parsing date '%s' of item '%s'", d[j].Isodate, d[j].Title)
 	}
 	if idate.Equal(jdate) {
 		return d[i].Title < d[j].Title
@@ -55,11 +55,11 @@ func (d doilist) Swap(i, j int) {
 // mkindex reads the provided XML files or URLs and generates the HTML landing
 // page for each.
 func mkindex(cmd *cobra.Command, args []string) {
-	fmt.Printf("Parsing %d files\n", len(args))
+	log.Printf("Parsing %d files\n", len(args))
 
 	var dois []doiitem
 	for idx, filearg := range args {
-		fmt.Printf("%3d: %s\n", idx, filearg)
+		log.Printf("%3d: %s\n", idx, filearg)
 		var contents []byte
 		var err error
 		if isURL(filearg) {
@@ -68,14 +68,14 @@ func mkindex(cmd *cobra.Command, args []string) {
 			contents, err = readFileAtPath(filearg)
 		}
 		if err != nil {
-			fmt.Printf("Failed to read file at %q: %s\n", filearg, err.Error())
+			log.Printf("Failed to read file at %q: %s\n", filearg, err.Error())
 			continue
 		}
 
 		datacite := new(libgin.DataCite)
 		err = xml.Unmarshal(contents, datacite)
 		if err != nil {
-			fmt.Printf("Failed to unmarshal contents of %q: %s\n", filearg, err.Error())
+			log.Printf("Failed to unmarshal contents of %q: %s\n", filearg, err.Error())
 			continue
 		}
 		metadata := &libgin.RepositoryMetadata{
@@ -94,13 +94,13 @@ func mkindex(cmd *cobra.Command, args []string) {
 	fname := "index.html"
 	tmpl, err := prepareTemplates("IndexPage")
 	if err != nil {
-		fmt.Printf("Error preparing template: %s", err.Error())
+		log.Printf("Error preparing template: %s", err.Error())
 		return
 	}
 
 	fp, err := os.Create(fname)
 	if err != nil {
-		fmt.Printf("Could not create the landing page file: %s", err.Error())
+		log.Printf("Could not create the landing page file: %s", err.Error())
 		return
 	}
 	defer fp.Close()
@@ -108,7 +108,7 @@ func mkindex(cmd *cobra.Command, args []string) {
 	// sorting the list of items by 1) date descending and 2) title ascending
 	sort.Sort(doilist(dois))
 	if err := tmpl.Execute(fp, dois); err != nil {
-		fmt.Printf("Error rendering the landing page: %s", err.Error())
+		log.Printf("Error rendering the landing page: %s", err.Error())
 		return
 	}
 }

--- a/cmd/gindoid/genindex_test.go
+++ b/cmd/gindoid/genindex_test.go
@@ -83,8 +83,8 @@ func TestMKIndex(t *testing.T) {
 		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
 	}
 
-	// create local test XML file server
-	server := serveDataciteXMLserver()
+	// create local test file server
+	server := serveDataciteServer()
 	defer server.Close()
 
 	// check local test server works

--- a/cmd/gindoid/genindex_test.go
+++ b/cmd/gindoid/genindex_test.go
@@ -54,7 +54,7 @@ func TestMKIndex(t *testing.T) {
 	// setup temp directory
 	targetpath, err := ioutil.TempDir("", "test_cli_index")
 	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
+		t.Fatalf("temp dir creation failed: %s", err.Error())
 	}
 	defer os.RemoveAll(targetpath)
 
@@ -108,6 +108,21 @@ func TestMKIndex(t *testing.T) {
 		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
 	}
 
+	// test save exit, no file created on invalid url
+	testEmptyXML := fmt.Sprintf("%s/empty-xml", server.URL)
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testEmptyXML})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on empty XML file URL: %s", err.Error())
+	}
+	fi, err = ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
 	// test save exit, no file created on non-xml datacite content
 	testNonXML := fmt.Sprintf("%s/non-xml", server.URL)
 	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testNonXML})
@@ -128,13 +143,13 @@ func TestMKIndex(t *testing.T) {
 	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testXML, testXML})
 	err = cmd.Execute()
 	if err != nil {
-		t.Fatalf("Error on invalid file URL: %s", err.Error())
+		t.Fatalf("Error on valid file URL: %s", err.Error())
 	}
 
 	_, err = os.Stat(targetFile)
 	if errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("Could not find input file at: %s", targetFile)
+		t.Fatalf("Missing output file: %s", targetFile)
 	} else if err != nil {
-		t.Fatalf("Unexpected error writing output file: %s", err.Error())
+		t.Fatalf("Error writing output file: %s", err.Error())
 	}
 }

--- a/cmd/gindoid/genindex_test.go
+++ b/cmd/gindoid/genindex_test.go
@@ -1,6 +1,12 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 )
@@ -41,5 +47,94 @@ func TestDoilist(t *testing.T) {
 	sort.Sort(doilist(dois))
 	if dois[1].Title != titlesecond {
 		t.Fatalf("Failed secondary sorting by Title: %v", dois)
+	}
+}
+
+func TestMKIndex(t *testing.T) {
+	// setup temp directory
+	targetpath, err := ioutil.TempDir("", "test_cli_index")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(targetpath)
+
+	targetFile := filepath.Join(targetpath, "index.html")
+	clioption := "make-index"
+	cmd := setUpCommands("")
+
+	// check safe exit on non-existing output directory
+	cmd.SetArgs([]string{clioption, "-oidonotexist", "non-existing.xml"})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on non-existing output directory: %s", err.Error())
+	}
+
+	// check safe exit, no file created on non-existing input file
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), "non-existing.xml"})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on non-existing input file: %s", err.Error())
+	}
+	fi, err := ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
+	// create local test XML file server
+	server := serveDataciteXMLserver()
+	defer server.Close()
+
+	// check local test server works
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Could not parse server URL: %q", serverURL)
+	}
+
+	// test save exit, no file created on invalid url
+	testInvalidURL := fmt.Sprintf("%s/not-available", server.URL)
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testInvalidURL})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on invalid file URL: %s", err.Error())
+	}
+	fi, err = ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
+	// test save exit, no file created on non-xml datacite content
+	testNonXML := fmt.Sprintf("%s/non-xml", server.URL)
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testNonXML})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on non-xml file URL: %s", err.Error())
+	}
+	fi, err = ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
+	// test valid xml file handling
+	testXML := fmt.Sprintf("%s/xml", server.URL)
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testXML, testXML})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on invalid file URL: %s", err.Error())
+	}
+
+	_, err = os.Stat(targetFile)
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Could not find input file at: %s", targetFile)
+	} else if err != nil {
+		t.Fatalf("Unexpected error writing output file: %s", err.Error())
 	}
 }

--- a/cmd/gindoid/gensitemap.go
+++ b/cmd/gindoid/gensitemap.go
@@ -90,6 +90,11 @@ func mksitemap(cmd *cobra.Command, args []string) {
 		siteurls += fmt.Sprintf("https://doi.gin.g-node.org/%s/\n", item.Shorthash)
 	}
 
+	if siteurls == "" {
+		log.Printf("Sitemap filecontent empty, skipping empty file creation.")
+		return
+	}
+
 	fname := "urls.txt"
 	err := ioutil.WriteFile(fname, []byte(siteurls), 0664)
 	if err != nil {

--- a/cmd/gindoid/gensitemap.go
+++ b/cmd/gindoid/gensitemap.go
@@ -4,6 +4,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"sort"
 	"time"
 
@@ -25,11 +26,11 @@ func (d urllist) Len() int {
 func (d urllist) Less(i, j int) bool {
 	idate, err := time.Parse("2006-01-02", d[i].Isodate)
 	if err != nil {
-		fmt.Printf("Error parsing date '%s' of item '%s'", d[i].Isodate, d[i].Title)
+		log.Printf("Error parsing date '%s' of item '%s'", d[i].Isodate, d[i].Title)
 	}
 	jdate, err := time.Parse("2006-01-02", d[j].Isodate)
 	if err != nil {
-		fmt.Printf("Error parsing date '%s' of item '%s'", d[j].Isodate, d[j].Title)
+		log.Printf("Error parsing date '%s' of item '%s'", d[j].Isodate, d[j].Title)
 	}
 	if idate.Equal(jdate) {
 		return d[i].Title < d[j].Title
@@ -49,7 +50,7 @@ func mksitemap(cmd *cobra.Command, args []string) {
 
 	var urls []doiitem
 	for idx, filearg := range args {
-		fmt.Printf("%3d: %s\n", idx, filearg)
+		log.Printf("%3d: %s\n", idx, filearg)
 		var contents []byte
 		var err error
 		if isURL(filearg) {
@@ -58,14 +59,14 @@ func mksitemap(cmd *cobra.Command, args []string) {
 			contents, err = readFileAtPath(filearg)
 		}
 		if err != nil {
-			fmt.Printf("Failed to read file at %q: %s\n", filearg, err.Error())
+			log.Printf("Failed to read file at %q: %s\n", filearg, err.Error())
 			continue
 		}
 
 		datacite := new(libgin.DataCite)
 		err = xml.Unmarshal(contents, datacite)
 		if err != nil {
-			fmt.Printf("Failed to unmarshal contents of %q: %s\n", filearg, err.Error())
+			log.Printf("Failed to unmarshal contents of %q: %s\n", filearg, err.Error())
 			continue
 		}
 		metadata := &libgin.RepositoryMetadata{
@@ -92,6 +93,6 @@ func mksitemap(cmd *cobra.Command, args []string) {
 	fname := "urls.txt"
 	err := ioutil.WriteFile(fname, []byte(siteurls), 0664)
 	if err != nil {
-		fmt.Printf("Error writing sitemap file: %s", err.Error())
+		log.Printf("Error writing sitemap file: %s\n", err.Error())
 	}
 }

--- a/cmd/gindoid/gensitemap.go
+++ b/cmd/gindoid/gensitemap.go
@@ -76,6 +76,15 @@ func mksitemap(xmlFiles []string, outpath string) {
 			DataCite: datacite,
 		}
 
+		if len(metadata.Titles) < 1 {
+			log.Printf("Could not parse DOI title, skipping '%s'\n", filearg)
+			continue
+		}
+		if len(metadata.Dates) < 1 {
+			log.Printf("Could not parse DOI date issued, skipping '%s'\n", filearg)
+			continue
+		}
+
 		// required to sort list
 		curr := doiitem{
 			Title:     metadata.Titles[0],

--- a/cmd/gindoid/gensitemap_test.go
+++ b/cmd/gindoid/gensitemap_test.go
@@ -93,7 +93,7 @@ func TestMKSitemap(t *testing.T) {
 		t.Fatalf("Could not parse server URL: %q", serverURL)
 	}
 
-	// test save exit, no file created on invalid url
+	// test safe exit, no file created on invalid url
 	testInvalidURL := fmt.Sprintf("%s/not-available", server.URL)
 	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testInvalidURL})
 	err = cmd.Execute()
@@ -108,7 +108,7 @@ func TestMKSitemap(t *testing.T) {
 		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
 	}
 
-	// test save exit, no file created on empty xml file
+	// test safe exit, no file created on empty xml file
 	testEmptyXML := fmt.Sprintf("%s/empty-xml", server.URL)
 	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testEmptyXML})
 	err = cmd.Execute()
@@ -123,7 +123,7 @@ func TestMKSitemap(t *testing.T) {
 		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
 	}
 
-	// test save exit, no file created on non-xml datacite content
+	// test safe exit, no file created on non-xml datacite content
 	testNonXML := fmt.Sprintf("%s/non-xml", server.URL)
 	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testNonXML})
 	err = cmd.Execute()

--- a/cmd/gindoid/gensitemap_test.go
+++ b/cmd/gindoid/gensitemap_test.go
@@ -1,6 +1,12 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 )
@@ -41,5 +47,76 @@ func TestURLlist(t *testing.T) {
 	sort.Sort(urllist(dois))
 	if dois[0].Title != titlefirst || dois[1].Title != titlesecond {
 		t.Fatalf("Failed secondary sorting by Title: %v", dois)
+	}
+}
+
+func TestMKSitemap(t *testing.T) {
+	targetpath, err := ioutil.TempDir("", "test_sitemap_cli")
+	if err != nil {
+		t.Fatalf("Failed to create sitemap cli temp directory: %v", err)
+	}
+	defer os.RemoveAll(targetpath)
+
+	cmd := setUpCommands("")
+
+	// check safe exit on non-existing output directory
+	cmd.SetArgs([]string{"make-sitemap", "-oidonotexist", "non-existing.xml"})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on non-existing sitemap directory: %s", err.Error())
+	}
+
+	// check safe exit on non-existing input file
+	cmd.SetArgs([]string{"make-sitemap", fmt.Sprintf("-o%s", targetpath), "non-existing.xml"})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on non-existing sitemap directory: %s", err.Error())
+	}
+	fi, err := ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
+	// create local test XML file server
+	server := serveDataciteXMLserver()
+	defer server.Close()
+
+	// check local test server works
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Could not parse server URL: %q", serverURL)
+	}
+
+	// test error on invalid datacite content
+	testNonXML := fmt.Sprintf("%s/non-xml", server.URL)
+	cmd.SetArgs([]string{"make-sitemap", fmt.Sprintf("-o%s", targetpath), testNonXML})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on invalid sitemap file URL: %s", err.Error())
+	}
+	fi, err = ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
+	// test valid xml file handling
+	testXML := fmt.Sprintf("%s/xml", server.URL)
+	cmd.SetArgs([]string{"make-sitemap", fmt.Sprintf("-o%s", targetpath), testXML, testXML})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on invalid sitemap file URL: %s", err.Error())
+	}
+	targetFile := filepath.Join(targetpath, "urls.txt")
+	_, err = os.Stat(targetFile)
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Could not find sitemap file at: %s", targetFile)
+	} else if err != nil {
+		t.Fatalf("Unexpected error writing sitemap file: %s", err.Error())
 	}
 }

--- a/cmd/gindoid/gensitemap_test.go
+++ b/cmd/gindoid/gensitemap_test.go
@@ -83,8 +83,8 @@ func TestMKSitemap(t *testing.T) {
 		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
 	}
 
-	// create local test XML file server
-	server := serveDataciteXMLserver()
+	// create local test file server
+	server := serveDataciteServer()
 	defer server.Close()
 
 	// check local test server works

--- a/cmd/gindoid/gensitemap_test.go
+++ b/cmd/gindoid/gensitemap_test.go
@@ -54,7 +54,7 @@ func TestMKSitemap(t *testing.T) {
 	// setup temp directory
 	targetpath, err := ioutil.TempDir("", "test_sitemap_cli")
 	if err != nil {
-		t.Fatalf("Failed to create sitemap cli temp directory: %v", err)
+		t.Fatalf("temp dir creation failed: %s", err.Error())
 	}
 	defer os.RemoveAll(targetpath)
 
@@ -66,7 +66,7 @@ func TestMKSitemap(t *testing.T) {
 	cmd.SetArgs([]string{clioption, "-oidonotexist", "non-existing.xml"})
 	err = cmd.Execute()
 	if err != nil {
-		t.Fatalf("Error on non-existing sitemap directory: %s", err.Error())
+		t.Fatalf("Error on non-existing directory: %s", err.Error())
 	}
 
 	// check safe exit, no file created on non-existing input file
@@ -108,6 +108,21 @@ func TestMKSitemap(t *testing.T) {
 		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
 	}
 
+	// test save exit, no file created on empty xml file
+	testEmptyXML := fmt.Sprintf("%s/empty-xml", server.URL)
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testEmptyXML})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on empty XML file URL: %s", err.Error())
+	}
+	fi, err = ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
 	// test save exit, no file created on non-xml datacite content
 	testNonXML := fmt.Sprintf("%s/non-xml", server.URL)
 	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testNonXML})
@@ -128,13 +143,13 @@ func TestMKSitemap(t *testing.T) {
 	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testXML, testXML})
 	err = cmd.Execute()
 	if err != nil {
-		t.Fatalf("Error on invalid file URL: %s", err.Error())
+		t.Fatalf("Error on valid file URL: %s", err.Error())
 	}
 
 	_, err = os.Stat(targetFile)
 	if errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("Could not find input file at: %s", targetFile)
+		t.Fatalf("Missing output file: %s", targetFile)
 	} else if err != nil {
-		t.Fatalf("Unexpected error writing output file: %s", err.Error())
+		t.Fatalf("Error writing output file: %s", err.Error())
 	}
 }

--- a/cmd/gindoid/genxml.go
+++ b/cmd/gindoid/genxml.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,6 +63,12 @@ func mkxml(ymlFiles []string, outpath string) {
 			continue
 		}
 
+		// skip empty files
+		if string(contents) == "" {
+			fmt.Printf("File %q is empty, skipping\n", filearg)
+			continue
+		}
+
 		dataciteContent, err := readRepoYAML(contents)
 		if err != nil {
 			fmt.Printf("DOI file invalid: %s\n", err.Error())
@@ -122,10 +127,10 @@ func clixml(cmd *cobra.Command, args []string) {
 	var outpath string
 	oval, err := cmd.Flags().GetString("out")
 	if err != nil {
-		log.Printf("-- Error parsing output directory flag: %s\n", err.Error())
+		fmt.Printf("-- Error parsing output directory flag: %s\n", err.Error())
 	} else if oval != "" {
 		outpath = oval
-		log.Printf("-- Using output directory '%s'\n", outpath)
+		fmt.Printf("-- Using output directory '%s'\n", outpath)
 	}
 
 	mkxml(args, outpath)

--- a/cmd/gindoid/genxml.go
+++ b/cmd/gindoid/genxml.go
@@ -80,6 +80,12 @@ func mkxml(ymlFiles []string, outpath string) {
 			fmt.Printf("DOI file contains validation issues: %s\n", strings.Join(msgs, "; "))
 		}
 
+		// avoid panic on missing license
+		if dataciteContent.License == nil {
+			dataciteContent.License = &libgin.License{}
+			fmt.Print("DOI file does not provide a License\n")
+		}
+
 		datacite := libgin.NewDataCiteFromYAML(dataciteContent)
 
 		// Create storage directory

--- a/cmd/gindoid/genxml.go
+++ b/cmd/gindoid/genxml.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -30,10 +31,10 @@ func getGINDataciteURL(input string) (string, error) {
 // a direct file and generates a Datacite XML file for each.
 // Reading files from GIN requires only the repository owner and the repository name
 // of the GIN repository prefixed with GIN in the format "GIN:[owner]/[repository]"
-func mkxml(cmd *cobra.Command, args []string) {
-	fmt.Printf("Generating %d xml files\n", len(args))
+func mkxml(ymlFiles []string, outpath string) {
+	fmt.Printf("Generating %d xml files\n", len(ymlFiles))
 	var success int
-	for idx, filearg := range args {
+	for idx, filearg := range ymlFiles {
 		fmt.Printf("%3d: %s\n", idx, filearg)
 		var contents []byte
 		var err error
@@ -109,6 +110,23 @@ func mkxml(cmd *cobra.Command, args []string) {
 		success++
 	}
 
-	fmt.Printf("%d/%d jobs completed successfully\n", success, len(args))
+	fmt.Printf("%d/%d jobs completed successfully\n", success, len(ymlFiles))
 	fmt.Print("\nRemember to add the G-Node identifier and check and adjust sizes and publication dates\n")
+}
+
+// clixml handles command line arguments and passes them
+// to the mkxml function.
+// An optional output file path can be passed via the command
+// line arguments; default output path is the current working directory.
+func clixml(cmd *cobra.Command, args []string) {
+	var outpath string
+	oval, err := cmd.Flags().GetString("out")
+	if err != nil {
+		log.Printf("-- Error parsing output directory flag: %s\n", err.Error())
+	} else if oval != "" {
+		outpath = oval
+		log.Printf("-- Using output directory '%s'\n", outpath)
+	}
+
+	mkxml(args, outpath)
 }

--- a/cmd/gindoid/genxml.go
+++ b/cmd/gindoid/genxml.go
@@ -38,6 +38,7 @@ func mkxml(cmd *cobra.Command, args []string) {
 		var contents []byte
 		var err error
 		var repoName string
+
 		if strings.HasPrefix(filearg, "GIN:") {
 			repostring := strings.Replace(filearg, "GIN:", "", 1)
 			ginurl, err := getGINDataciteURL(repostring)
@@ -49,12 +50,10 @@ func mkxml(cmd *cobra.Command, args []string) {
 			if len(repodata) == 2 {
 				repoName = repodata[1]
 			}
-			contents, err = readFileAtURL(ginurl)
-			if err != nil {
-				fmt.Printf("Failed to read file at %q: %s\n", ginurl, err.Error())
-				continue
-			}
-		} else if isURL(filearg) {
+			filearg = ginurl
+		}
+
+		if isURL(filearg) {
 			contents, err = readFileAtURL(filearg)
 		} else {
 			contents, err = readFileAtPath(filearg)
@@ -89,15 +88,14 @@ func mkxml(cmd *cobra.Command, args []string) {
 
 		fp, err := os.Create(fname)
 		if err != nil {
-			// XML Creation failed; return with error
-			fmt.Printf("Failed to create the XML metadata file: %s", err)
+			fmt.Printf("Failed to create the metadata XML file: %s", err)
 			continue
 		}
 		defer fp.Close()
 
 		data, err := datacite.Marshal()
 		if err != nil {
-			fmt.Printf("Failed to render the XML metadata file: %s", err)
+			fmt.Printf("Failed to render the metadata XML file: %s", err)
 			continue
 		}
 		_, err = fp.Write([]byte(data))

--- a/cmd/gindoid/genxml.go
+++ b/cmd/gindoid/genxml.go
@@ -92,9 +92,10 @@ func mkxml(ymlFiles []string, outpath string) {
 		if repoName == "" {
 			repoName = fmt.Sprintf("index-%03d", idx)
 		}
-		fname := filepath.Join(repoName, "doi.xml")
-		if err = os.MkdirAll(repoName, 0777); err != nil {
-			fmt.Printf("WARNING: Could not create directory %s: %q", repoName, err.Error())
+		dirname := filepath.Join(outpath, repoName)
+		fname := filepath.Join(outpath, repoName, "doi.xml")
+		if err = os.MkdirAll(dirname, 0777); err != nil {
+			fmt.Printf("WARNING: Could not create directory %s: %q", dirname, err.Error())
 			fname = fmt.Sprintf("%s-doi.xml", repoName)
 		}
 

--- a/cmd/gindoid/genxml_test.go
+++ b/cmd/gindoid/genxml_test.go
@@ -1,6 +1,12 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -21,5 +27,97 @@ func TestGetGINDataciteURL(t *testing.T) {
 	_, err = getGINDataciteURL("repoown/reponame")
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+}
+
+func TestMKxml(t *testing.T) {
+	// setup temp directory
+	targetpath, err := ioutil.TempDir("", "test_cli_xml")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(targetpath)
+
+	clioption := "make-xml"
+	cmd := setUpCommands("")
+
+	// check safe exit on non-existing output directory
+	cmd.SetArgs([]string{clioption, "-oidonotexist", "non-existing.yml"})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on non-existing output directory: %s", err.Error())
+	}
+
+	// check safe exit, no file created on non-existing input file
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), "non-existing.yml"})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on non-existing input file: %s", err.Error())
+	}
+	fi, err := ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
+	// create local test file server
+	server := serveDataciteServer()
+	defer server.Close()
+
+	// check local test server works
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Could not parse server URL: %q", serverURL)
+	}
+
+	// test safe exit, no file created on invalid file url, non-existing gin repo
+	// this pings GIN server actual; could be refactored to avoid this fact.
+	testInvalidURL := fmt.Sprintf("%s/not-available", server.URL)
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testInvalidURL, "GIN:invalid", "GIN:not/exist"})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on invalid file URL: %s", err.Error())
+	}
+	fi, err = ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
+	// test safe exit, no file created on empty and invalid yaml file
+	testInvalidYML := fmt.Sprintf("%s/non-xml", server.URL)
+	testEmpty := fmt.Sprintf("%s/empty", server.URL)
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testInvalidYML, testEmpty})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on invalid file: %s", err.Error())
+	}
+	fi, err = ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
+	// test valid file creation on valid file and no error on empty file
+	testValidYML := fmt.Sprintf("%s/dc-yml", server.URL)
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testValidYML})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on invalid file: %s", err.Error())
+	}
+
+	// check valid output directory and file
+	target := filepath.Join(targetpath, "index-000", "doi.xml")
+	_, err = os.Stat(target)
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Missing output file: %q", target)
+	} else if err != nil {
+		t.Fatalf("Error accessing file: %s", err.Error())
 	}
 }

--- a/cmd/gindoid/genxml_test.go
+++ b/cmd/gindoid/genxml_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGetGINDataciteURL(t *testing.T) {
+	// test error on empty input
+	_, err := getGINDataciteURL("")
+	if err == nil {
+		t.Fatal("Expected fail on empty input")
+	}
+
+	// test error on missing separator
+	_, err = getGINDataciteURL("unsupported entry")
+	if err == nil {
+		t.Fatal("Expected fail on non parsable input")
+	}
+
+	// test valid input
+	_, err = getGINDataciteURL("repoown/reponame")
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err.Error())
+	}
+}

--- a/cmd/gindoid/keywords.go
+++ b/cmd/gindoid/keywords.go
@@ -54,6 +54,11 @@ func mkkeywords(xmlFiles []string, outpath string) {
 			DataCite: datacite,
 		}
 
+		if metadata == nil || metadata.Subjects == nil {
+			fmt.Printf("Invalid subjects, skipping file '%s'", filearg)
+			continue
+		}
+
 		for _, kw := range *metadata.Subjects {
 			kw = KeywordPath(kw)
 			datasets := keywordMap[kw]
@@ -86,8 +91,10 @@ func mkkeywords(xmlFiles []string, outpath string) {
 			continue
 		}
 		defer fp.Close()
+
 		data := make(map[string]interface{})
 		data["Keyword"] = kw
+
 		// Sort by date, lex order, which for ISO date strings should work fine
 		sort.Slice(datasets, func(i, j int) bool {
 			return datasets[i].Dates[0].Value > datasets[j].Dates[0].Value

--- a/cmd/gindoid/keywords.go
+++ b/cmd/gindoid/keywords.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -12,12 +13,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func mkkeywords(cmd *cobra.Command, args []string) {
+func mkkeywords(xmlFiles []string, outpath string) {
 	// map keywords to DOIs
 	keywordMap := make(map[string][]*libgin.RepositoryMetadata)
 
 	fmt.Println("Reading files")
-	for idx, filearg := range args {
+	for idx, filearg := range xmlFiles {
 		var contents []byte
 		var err error
 		if isURL(filearg) {
@@ -59,7 +60,7 @@ func mkkeywords(cmd *cobra.Command, args []string) {
 			datasets = append(datasets, metadata)
 			keywordMap[kw] = datasets
 		}
-		fmt.Printf(" %d/%d\r", idx+1, len(args))
+		fmt.Printf(" %d/%d\r", idx+1, len(xmlFiles))
 	}
 
 	fmt.Printf("\nFound %d keywords\n", len(keywordMap))
@@ -71,13 +72,15 @@ func mkkeywords(cmd *cobra.Command, args []string) {
 			continue
 		}
 		// use a "keywords" root directory
-		err = os.MkdirAll(fmt.Sprintf("keywords/%s", kw), 0777)
+		rootpath := filepath.Join(outpath, "keywords", kw)
+		err = os.MkdirAll(rootpath, 0777)
 		if err != nil {
 			log.Printf("Could not create the keyword page dir: %s", err.Error())
 			continue
 		}
 
-		fp, err := os.Create(fmt.Sprintf("keywords/%s/index.html", kw))
+		idxfp := filepath.Join(outpath, "keywords", kw, "index.html")
+		fp, err := os.Create(idxfp)
 		if err != nil {
 			log.Printf("Could not create the keyword page file: %s", err.Error())
 			continue
@@ -121,7 +124,8 @@ func mkkeywords(cmd *cobra.Command, args []string) {
 	if err != nil {
 		return
 	}
-	fp, err := os.Create("keywords/index.html")
+	kwidxpath := filepath.Join(outpath, "keywords", "index.html")
+	fp, err := os.Create(kwidxpath)
 	if err != nil {
 		log.Printf("Could not create the keyword list page file: %s", err.Error())
 		return
@@ -131,4 +135,21 @@ func mkkeywords(cmd *cobra.Command, args []string) {
 	if err := tmpl.Execute(fp, data); err != nil {
 		log.Printf("Error rendering keyword list page: %s", err.Error())
 	}
+}
+
+// clikeywords handles command line arguments and passes them
+// to the mkkeywords function.
+// An optional output file path can be passed via the command
+// line arguments; default output path is the current working directory.
+func clikeywords(cmd *cobra.Command, args []string) {
+	var outpath string
+	oval, err := cmd.Flags().GetString("out")
+	if err != nil {
+		log.Printf("-- Error parsing output directory flag: %s\n", err.Error())
+	} else if oval != "" {
+		outpath = oval
+		log.Printf("-- Using output directory '%s'\n", outpath)
+	}
+
+	mkkeywords(args, outpath)
 }

--- a/cmd/gindoid/keywords_test.go
+++ b/cmd/gindoid/keywords_test.go
@@ -52,7 +52,7 @@ func TestMKkeywords(t *testing.T) {
 		t.Fatalf("Could not parse server URL: %q", serverURL)
 	}
 
-	// test save exit, no file created on invalid url
+	// test safe exit, no file created on invalid url
 	testInvalidURL := fmt.Sprintf("%s/not-available", server.URL)
 	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testInvalidURL})
 	err = cmd.Execute()
@@ -67,7 +67,7 @@ func TestMKkeywords(t *testing.T) {
 		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
 	}
 
-	// test save exit, no file created on invalid url
+	// test safe exit, no file created on invalid url
 	testEmptyXML := fmt.Sprintf("%s/empty-xml", server.URL)
 	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testEmptyXML})
 	err = cmd.Execute()
@@ -82,7 +82,7 @@ func TestMKkeywords(t *testing.T) {
 		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
 	}
 
-	// test save exit, no file created on non-xml datacite content
+	// test safe exit, no file created on non-xml datacite content
 	testNonXML := fmt.Sprintf("%s/non-xml", server.URL)
 	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testNonXML})
 	err = cmd.Execute()

--- a/cmd/gindoid/keywords_test.go
+++ b/cmd/gindoid/keywords_test.go
@@ -42,8 +42,8 @@ func TestMKkeywords(t *testing.T) {
 		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
 	}
 
-	// create local test XML file server
-	server := serveDataciteXMLserver()
+	// create local test file server
+	server := serveDataciteServer()
 	defer server.Close()
 
 	// check local test server works

--- a/cmd/gindoid/keywords_test.go
+++ b/cmd/gindoid/keywords_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMKkeywords(t *testing.T) {
+	// setup temp directory
+	targetpath, err := ioutil.TempDir("", "test_cli_keywords")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(targetpath)
+
+	clioption := "make-keyword-pages"
+	cmd := setUpCommands("")
+
+	// check safe exit on non-existing output directory
+	cmd.SetArgs([]string{clioption, "-oidonotexist", "non-existing.xml"})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on non-existing output directory: %s", err.Error())
+	}
+
+	// check safe exit, no file created on non-existing input file
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), "non-existing.xml"})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on non-existing input file: %s", err.Error())
+	}
+	fi, err := ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
+	// create local test XML file server
+	server := serveDataciteXMLserver()
+	defer server.Close()
+
+	// check local test server works
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Could not parse server URL: %q", serverURL)
+	}
+
+	// test save exit, no file created on invalid url
+	testInvalidURL := fmt.Sprintf("%s/not-available", server.URL)
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testInvalidURL})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on invalid file URL: %s", err.Error())
+	}
+	fi, err = ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
+	// test save exit, no file created on invalid url
+	testEmptyXML := fmt.Sprintf("%s/empty-xml", server.URL)
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testEmptyXML})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on empty XML file URL: %s", err.Error())
+	}
+	fi, err = ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
+	// test save exit, no file created on non-xml datacite content
+	testNonXML := fmt.Sprintf("%s/non-xml", server.URL)
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testNonXML})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on non-xml file URL: %s", err.Error())
+	}
+	fi, err = ioutil.ReadDir(targetpath)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 0 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+
+	// test valid xml file handling
+	testXML := fmt.Sprintf("%s/xml", server.URL)
+	cmd.SetArgs([]string{clioption, fmt.Sprintf("-o%s", targetpath), testXML, testXML})
+	err = cmd.Execute()
+	if err != nil {
+		t.Fatalf("Error on valid file URL: %s", err.Error())
+	}
+
+	// check keyword list index page
+	targetListIndex := filepath.Join(targetpath, "keywords", "index.html")
+	_, err = os.Stat(targetListIndex)
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Missing output file: %s", targetListIndex)
+	} else if err != nil {
+		t.Fatalf("Error accessing file: %s", err.Error())
+	}
+
+	// check keyword landing index page
+	targetKeyIndex := filepath.Join(targetpath, "keywords", "test_keyword", "index.html")
+	_, err = os.Stat(targetKeyIndex)
+	if errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Missing output file: %s", targetKeyIndex)
+	} else if err != nil {
+		t.Fatalf("Error accessing file: %s", err.Error())
+	}
+
+	targetDir := filepath.Join(targetpath, "keywords")
+	fi, err = ioutil.ReadDir(targetDir)
+	if err != nil {
+		t.Fatalf("Error on reading target dir: %s", err.Error())
+	}
+	if len(fi) != 2 {
+		t.Fatalf("Encountered unexpected number of files: %d/0", len(fi))
+	}
+}

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -87,10 +87,11 @@ The command accepts file paths and URLs (mixing allowed) and will generate one i
 
 The command accepts file paths and URLs (mixing allowed) and will generate one index HTML page containing the information of all XML files found.`,
 		Args:                  cobra.MinimumNArgs(1),
-		Run:                   mksitemap,
+		Run:                   clisitemap,
 		Version:               verstr,
 		DisableFlagsInUseLine: true,
 	}
+	cmds[5].Flags().StringP("out", "o", "", "[OPTIONAL] output file directory; must exist")
 	cmds[6] = &cobra.Command{
 		Use:   "make-all <xml file>...",
 		Short: "Generate all html files and the google sitemap file.",
@@ -104,6 +105,7 @@ the keywords html pages and all DOI html landing pages from the XML files.`,
 		Version:               verstr,
 		DisableFlagsInUseLine: true,
 	}
+	cmds[6].Flags().StringP("out", "o", "", "[OPTIONAL] output file directory; must exist")
 	cmds[7] = &cobra.Command{
 		Use:   "make-checklist",
 		Short: "Generate a DOI registration checklist file.",

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -52,12 +52,14 @@ The command accepts file paths and URLs (mixing allowed) and will generate one H
 
 The command accepts file paths and URLs (mixing allowed) and will generate one HTML page for each unique keyword found in the XML files. Each page lists (and links to) all datasets that use the keyword.
 
-Previously generated pages are overwritten, so this command only makes sense if using all published XML files to generate complete listings.`,
+Previously generated pages are overwritten, so this command only makes sense if using all published XML files to generate complete listings.
+Using the optional '-o' argument an alternative output path can be specified.`,
 		Args:                  cobra.MinimumNArgs(1),
-		Run:                   mkkeywords,
+		Run:                   clikeywords,
 		Version:               verstr,
 		DisableFlagsInUseLine: true,
 	}
+	cmds[2].Flags().StringP("out", "o", "", "[OPTIONAL] output file directory; must exist")
 	cmds[3] = &cobra.Command{
 		Use:   "make-xml <yml file>...",
 		Short: "Generate the doi.xml file from one or more DataCite YAML files",
@@ -74,7 +76,8 @@ The command accepts GIN repositories of format "GIN:owner/repository", yaml file
 		Short: "Generate the index.html file from one or more DataCite XML files",
 		Long: `Generate the index.html file from one or more DataCite XML files.
 
-The command accepts file paths and URLs (mixing allowed) and will generate one index HTML page containing the information of all XML files found.`,
+The command accepts file paths and URLs (mixing allowed) and will generate one index HTML page containing the information of all XML files found.
+Using the optional '-o' argument an alternative output path can be specified.`,
 		Args:                  cobra.MinimumNArgs(1),
 		Run:                   cliindex,
 		Version:               verstr,
@@ -86,7 +89,8 @@ The command accepts file paths and URLs (mixing allowed) and will generate one i
 		Short: "Generate the urls.txt google sitemap file from one or more DataCite XML files",
 		Long: `Generate the urls.txt google sitemap file from one or more DataCite XML files.
 
-The command accepts file paths and URLs (mixing allowed) and will generate one index HTML page containing the information of all XML files found.`,
+The command accepts file paths and URLs (mixing allowed) and will generate one index HTML page containing the information of all XML files found.
+Using the optional '-o' argument an alternative output path can be specified.`,
 		Args:                  cobra.MinimumNArgs(1),
 		Run:                   clisitemap,
 		Version:               verstr,
@@ -100,7 +104,8 @@ The command accepts file paths and URLs (mixing allowed) and will generate one i
 
 The command accepts file paths and URLs (mixing allowed) of DOI XML files 
 and will generate the root landing HTML page, the google sitemap urls.txt file, 
-the keywords html pages and all DOI html landing pages from the XML files.`,
+the keywords html pages and all DOI html landing pages from the XML files.
+Using the optional '-o' argument an alternative output path can be specified.`,
 		Args:                  cobra.MinimumNArgs(1),
 		Run:                   mkall,
 		Version:               verstr,

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -81,10 +81,11 @@ to retrieve the metadata by querying the online resources. If that fails, a warn
 is printed and the file is still generated with the available information. 
 Contextual information like size or date have to be added manually.`,
 		Args:                  cobra.MinimumNArgs(1),
-		Run:                   mkxml,
+		Run:                   clixml,
 		Version:               verstr,
 		DisableFlagsInUseLine: true,
 	}
+	cmds[3].Flags().StringP("out", "o", "", "[OPTIONAL] output file directory; must exist")
 	cmds[4] = &cobra.Command{
 		Use:   "make-index <xml file>...",
 		Short: "Generate the index.html list file from one or more DataCite XML files",

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -39,8 +39,12 @@ func setUpCommands(verstr string) *cobra.Command {
 		Short: "Generate the HTML landing page from one or more DataCite XML files",
 		Long: `Generate the HTML landing page from one or more DataCite XML files.
 
-The command accepts file paths and URLs (mixing allowed) and will generate one HTML page for each XML file found. If the page generation requires information that is missing from the XML file (e.g., archive file size, repository URLs), the program will attempt to retrieve the metadata by querying the online resources. If that fails, a warning is printed and the page is still generated with the available information.
-Using the optional '-o' argument an alternative output path can be specified.`,
+The command accepts file paths and URLs (mixing allowed) and will generate one 
+HTML page for each XML file found. If the page generation requires information that 
+is missing from the XML file (e.g., archive file size, repository URLs), the program 
+will attempt to retrieve the metadata by querying the online resources. 
+If that fails, a warning is printed and the page is still generated with the available 
+information.`,
 		Args:                  cobra.MinimumNArgs(1),
 		Run:                   clihtml,
 		Version:               verstr,
@@ -52,10 +56,12 @@ Using the optional '-o' argument an alternative output path can be specified.`,
 		Short: "Generate keyword index pages",
 		Long: `Generate keyword index pages.
 
-The command accepts file paths and URLs (mixing allowed) and will generate one HTML page for each unique keyword found in the XML files. Each page lists (and links to) all datasets that use the keyword.
+The command accepts file paths and URLs (mixing allowed) and will generate one HTML page 
+for each unique keyword found in the XML files. Each page lists (and links to) all 
+datasets that use the keyword.
 
-Previously generated pages are overwritten, so this command only makes sense if using all published XML files to generate complete listings.
-Using the optional '-o' argument an alternative output path can be specified.`,
+Previously generated pages are overwritten, so this command only makes sense if using 
+all published XML files to generate complete listings.`,
 		Args:                  cobra.MinimumNArgs(1),
 		Run:                   clikeywords,
 		Version:               verstr,
@@ -67,7 +73,13 @@ Using the optional '-o' argument an alternative output path can be specified.`,
 		Short: "Generate the doi.xml file from one or more DataCite YAML files",
 		Long: `Generate the doi.xml file from one or more DataCite YAML files.
 
-The command accepts GIN repositories of format "GIN:owner/repository", yaml file paths and URLs to yaml files (mixing allowed) and will generate one XML file for each YAML file found. If the page generation requires information that is missing from the XML file (e.g., archive file size, repository URLs), the program will attempt to retrieve the metadata by querying the online resources. If that fails, a warning is printed and the file is still generated with the available information. Contextual information like size or date have to be added manually.`,
+The command accepts GIN repositories of format "GIN:owner/repository", yaml file paths 
+and URLs to yaml files (mixing allowed) and will generate one XML file for each 
+YAML file found. If the page generation requires information that is missing from 
+the XML file (e.g., archive file size, repository URLs), the program will attempt 
+to retrieve the metadata by querying the online resources. If that fails, a warning 
+is printed and the file is still generated with the available information. 
+Contextual information like size or date have to be added manually.`,
 		Args:                  cobra.MinimumNArgs(1),
 		Run:                   mkxml,
 		Version:               verstr,
@@ -75,11 +87,11 @@ The command accepts GIN repositories of format "GIN:owner/repository", yaml file
 	}
 	cmds[4] = &cobra.Command{
 		Use:   "make-index <xml file>...",
-		Short: "Generate the index.html file from one or more DataCite XML files",
-		Long: `Generate the index.html file from one or more DataCite XML files.
+		Short: "Generate the index.html list file from one or more DataCite XML files",
+		Long: `Generate the index.html list file from one or more DataCite XML files.
 
-The command accepts file paths and URLs (mixing allowed) and will generate one index HTML page containing the information of all XML files found.
-Using the optional '-o' argument an alternative output path can be specified.`,
+The command accepts file paths and URLs (mixing allowed) and will generate one 
+DOI listing index HTML page containing the information of all XML files provided.`,
 		Args:                  cobra.MinimumNArgs(1),
 		Run:                   cliindex,
 		Version:               verstr,
@@ -91,8 +103,9 @@ Using the optional '-o' argument an alternative output path can be specified.`,
 		Short: "Generate the urls.txt google sitemap file from one or more DataCite XML files",
 		Long: `Generate the urls.txt google sitemap file from one or more DataCite XML files.
 
-The command accepts file paths and URLs (mixing allowed) and will generate one index HTML page containing the information of all XML files found.
-Using the optional '-o' argument an alternative output path can be specified.`,
+The command accepts file paths and URLs (mixing allowed) and will generate one 
+google sitemap file named 'urls.txt' containing the DOI links found in the Datacite 
+XML files provided.`,
 		Args:                  cobra.MinimumNArgs(1),
 		Run:                   clisitemap,
 		Version:               verstr,
@@ -106,8 +119,7 @@ Using the optional '-o' argument an alternative output path can be specified.`,
 
 The command accepts file paths and URLs (mixing allowed) of DOI XML files 
 and will generate the root landing HTML page, the google sitemap urls.txt file, 
-the keywords html pages and all DOI html landing pages from the XML files.
-Using the optional '-o' argument an alternative output path can be specified.`,
+the keywords html pages and all DOI html landing pages from the XML files.`,
 		Args:                  cobra.MinimumNArgs(1),
 		Run:                   mkall,
 		Version:               verstr,
@@ -122,10 +134,10 @@ Using the optional '-o' argument an alternative output path can be specified.`,
 The command will create a markdown file containing a DOI dataset registration checklist.
 By default all variables will contain placeholder text and the file will be placed at the
 executing path.
-Using the optional '-o' argument an alternative output path can be specified.
-Using the optional '-c' argument a yaml config file can be specified to automatically
+
+Using the optional '-c' argument, a yaml config file can be specified to automatically
 replace the default variable values. If a config file is specified, the service will 
-additionally try to fetch dataset 'title' and 'authors' from the corresponding gin repository.`,
+additionally try to fetch dataset 'title' and 'authors' from the corresponding GIN repository.`,
 		Args:                  cobra.MinimumNArgs(0),
 		Run:                   mkchecklistcli,
 		Version:               verstr,

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -39,12 +39,14 @@ func setUpCommands(verstr string) *cobra.Command {
 		Short: "Generate the HTML landing page from one or more DataCite XML files",
 		Long: `Generate the HTML landing page from one or more DataCite XML files.
 
-The command accepts file paths and URLs (mixing allowed) and will generate one HTML page for each XML file found. If the page generation requires information that is missing from the XML file (e.g., archive file size, repository URLs), the program will attempt to retrieve the metadata by querying the online resources. If that fails, a warning is printed and the page is still generated with the available information.`,
+The command accepts file paths and URLs (mixing allowed) and will generate one HTML page for each XML file found. If the page generation requires information that is missing from the XML file (e.g., archive file size, repository URLs), the program will attempt to retrieve the metadata by querying the online resources. If that fails, a warning is printed and the page is still generated with the available information.
+Using the optional '-o' argument an alternative output path can be specified.`,
 		Args:                  cobra.MinimumNArgs(1),
-		Run:                   mkhtml,
+		Run:                   clihtml,
 		Version:               verstr,
 		DisableFlagsInUseLine: true,
 	}
+	cmds[1].Flags().StringP("out", "o", "", "[OPTIONAL] output file directory; must exist")
 	cmds[2] = &cobra.Command{
 		Use:   "make-keyword-pages <xml file>...",
 		Short: "Generate keyword index pages",

--- a/cmd/gindoid/main.go
+++ b/cmd/gindoid/main.go
@@ -76,10 +76,11 @@ The command accepts GIN repositories of format "GIN:owner/repository", yaml file
 
 The command accepts file paths and URLs (mixing allowed) and will generate one index HTML page containing the information of all XML files found.`,
 		Args:                  cobra.MinimumNArgs(1),
-		Run:                   mkindex,
+		Run:                   cliindex,
 		Version:               verstr,
 		DisableFlagsInUseLine: true,
 	}
+	cmds[4].Flags().StringP("out", "o", "", "[OPTIONAL] output file directory; must exist")
 	cmds[5] = &cobra.Command{
 		Use:   "make-sitemap <xml file>...",
 		Short: "Generate the urls.txt google sitemap file from one or more DataCite XML files",

--- a/cmd/gindoid/testutils.go
+++ b/cmd/gindoid/testutils.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+)
+
+const invalidTestDataciteXML = `sometext`
+const validTestDataciteXML = `<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.3/metadata.xsd">
+  <identifier identifierType="DOI">10.12751/g-node.noex1st</identifier>
+  <creators>
+    <creator>
+      <creatorName>TestLastname, GivenName</creatorName>
+      <nameIdentifier schemeURI="http://orcid.org/" nameIdentifierScheme="ORCID">0000-000X-XXXX-XXXX</nameIdentifier>
+      <affiliation>Test Affiliation</affiliation>
+    </creator>
+  </creators>
+  <titles>
+    <title>Test title</title>
+  </titles>
+  <descriptions>
+    <description descriptionType="Abstract">Test abstract</description>
+  </descriptions>
+  <rightsList>
+    <rights rightsURI="https://opensource.org/licenses/BSD-3-Clause/">BSD-3-Clause</rights>
+  </rightsList>
+  <subjects>
+    <subject>Test keyword</subject>
+  </subjects>
+  <relatedIdentifiers>
+    <relatedIdentifier relatedIdentifierType="URL" relationType="IsVariantFormOf">https://doi.gin.g-node.org/10.12751/g-node.noex1st/10.12751_g-node.noex1st.zip</relatedIdentifier>
+  </relatedIdentifiers>
+  <fundingReferences>
+    <fundingReference>
+      <funderName>Test Funderreference</funderName>
+    </fundingReference>
+  </fundingReferences>
+  <contributors>
+    <contributor contributorType="HostingInstitution">
+      <contributorName>German Neuroinformatics Node</contributorName>
+    </contributor>
+  </contributors>
+  <publisher>G-Node</publisher>
+  <publicationYear>2021</publicationYear>
+  <dates>
+    <date dateType="Issued">2021-10-27</date>
+  </dates>
+  <language>eng</language>
+  <resourceType resourceTypeGeneral="Dataset">Dataset</resourceType>
+  <sizes>
+    <size>8.1 MiB</size>
+  </sizes>
+  <version>1.0</version>
+</resource>
+`
+
+// serveDataciteXMLserver provides a local test server for Datacite xml handling
+func serveDataciteXMLserver() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/non-xml", func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		_, err := rw.Write([]byte(invalidTestDataciteXML))
+		if err != nil {
+			fmt.Printf("Could not write invalid response: %q", err.Error())
+		}
+	})
+	mux.HandleFunc("/xml", func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		_, err := rw.Write([]byte(validTestDataciteXML))
+		if err != nil {
+			fmt.Printf("could not write valid response: %q", err.Error())
+		}
+	})
+
+	return httptest.NewServer(mux)
+}

--- a/cmd/gindoid/testutils.go
+++ b/cmd/gindoid/testutils.go
@@ -62,8 +62,8 @@ const emptyTestDataciteXML = `<?xml version="1.0" encoding="UTF-8"?>
 </resource>
 `
 
-// serveDataciteXMLserver provides a local test server for Datacite xml handling
-func serveDataciteXMLserver() *httptest.Server {
+// serveDataciteserver provides a local test server for Datacite xml handling
+func serveDataciteServer() *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/non-xml", func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)

--- a/cmd/gindoid/testutils.go
+++ b/cmd/gindoid/testutils.go
@@ -6,7 +6,8 @@ import (
 	"net/http/httptest"
 )
 
-const invalidTestDataciteXML = `sometext`
+const empty = ``
+const plainText = `plaintext`
 const validTestDataciteXML = `<?xml version="1.0" encoding="UTF-8"?>
 <resource xmlns="http://datacite.org/schema/kernel-4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.3/metadata.xsd">
   <identifier identifierType="DOI">10.12751/g-node.noex1st</identifier>
@@ -62,12 +63,33 @@ const emptyTestDataciteXML = `<?xml version="1.0" encoding="UTF-8"?>
 </resource>
 `
 
+const validTestDataciteYML = `
+authors:
+  -
+    firstname: "aaa"
+    lastname: "MadamA"
+    affiliation: "Department of Test simple author"
+
+# A title to describe the published resource.
+title: "Doi test"
+
+# Do not edit or remove the following line
+templateversion: 1.2
+`
+
 // serveDataciteserver provides a local test server for Datacite xml handling
 func serveDataciteServer() *httptest.Server {
 	mux := http.NewServeMux()
+	mux.HandleFunc("/empty", func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		_, err := rw.Write([]byte(empty))
+		if err != nil {
+			fmt.Printf("could not write valid response: %q", err.Error())
+		}
+	})
 	mux.HandleFunc("/non-xml", func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
-		_, err := rw.Write([]byte(invalidTestDataciteXML))
+		_, err := rw.Write([]byte(plainText))
 		if err != nil {
 			fmt.Printf("Could not write invalid response: %q", err.Error())
 		}
@@ -82,6 +104,13 @@ func serveDataciteServer() *httptest.Server {
 	mux.HandleFunc("/empty-xml", func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 		_, err := rw.Write([]byte(emptyTestDataciteXML))
+		if err != nil {
+			fmt.Printf("could not write valid response: %q", err.Error())
+		}
+	})
+	mux.HandleFunc("/dc-yml", func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		_, err := rw.Write([]byte(validTestDataciteYML))
 		if err != nil {
 			fmt.Printf("could not write valid response: %q", err.Error())
 		}

--- a/cmd/gindoid/testutils.go
+++ b/cmd/gindoid/testutils.go
@@ -56,6 +56,12 @@ const validTestDataciteXML = `<?xml version="1.0" encoding="UTF-8"?>
 </resource>
 `
 
+const emptyTestDataciteXML = `<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns="http://datacite.org/schema/kernel-4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.3/metadata.xsd">
+  <version>1.0</version>
+</resource>
+`
+
 // serveDataciteXMLserver provides a local test server for Datacite xml handling
 func serveDataciteXMLserver() *httptest.Server {
 	mux := http.NewServeMux()
@@ -69,6 +75,13 @@ func serveDataciteXMLserver() *httptest.Server {
 	mux.HandleFunc("/xml", func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 		_, err := rw.Write([]byte(validTestDataciteXML))
+		if err != nil {
+			fmt.Printf("could not write valid response: %q", err.Error())
+		}
+	})
+	mux.HandleFunc("/empty-xml", func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		_, err := rw.Write([]byte(emptyTestDataciteXML))
 		if err != nil {
 			fmt.Printf("could not write valid response: %q", err.Error())
 		}

--- a/cmd/gindoid/testutils.go
+++ b/cmd/gindoid/testutils.go
@@ -27,7 +27,7 @@ const validTestDataciteXML = `<?xml version="1.0" encoding="UTF-8"?>
     <rights rightsURI="https://opensource.org/licenses/BSD-3-Clause/">BSD-3-Clause</rights>
   </rightsList>
   <subjects>
-    <subject>Test keyword</subject>
+    <subject>Test_keyword</subject>
   </subjects>
   <relatedIdentifiers>
     <relatedIdentifier relatedIdentifierType="URL" relationType="IsVariantFormOf">https://doi.gin.g-node.org/10.12751/g-node.noex1st/10.12751_g-node.noex1st.zip</relatedIdentifier>


### PR DESCRIPTION
This PR pushes the test coverage for all the gindoid CLI options to create various types of files.

The PR further includes code refactoring of shortcomings revealed by the added tests e.g. uncaught nil pointer exceptions leading to potential panics. This includes the following changes:
- a `testutils` file is added featuring a `serverDataciteServer` func providing various valid and invalid datacite XML and YML files
- all gindoid CLI options creating output files now support the CLI option (`-o`) to provide an output file directory.
- `gensitemap` now skips the `urls.txt` file creation if no valid input files have been provided.
- `genindex` now skips the `index.html` file creation if no valid input files have been provided.
- `genxml` skips writing an output files on an empty input file.
- `genindex`, `gensitemap`, `keywords`, `genhtml` and `genxml` feature additional failsafes against various nil pointers.
