### PR TITLE
Fixes, cleanup and tests

### DIFF
--- a/cmd/gindoid/genall_test.go
+++ b/cmd/gindoid/genall_test.go
@@ -20,7 +20,7 @@ func TestMKall(t *testing.T) {
 	cmd := setUpCommands("")
 
 	// only check the CLI option with one valid file,
-	// the detailled tests should be handled via testing
+	// the detailed tests should be handled via testing
 	// the subcommands.
 
 	// create local test file server

--- a/cmd/gindoid/genxml.go
+++ b/cmd/gindoid/genxml.go
@@ -86,6 +86,21 @@ func mkxml(ymlFiles []string, outpath string) {
 			fmt.Print("DOI file does not provide a License\n")
 		}
 
+		// Permit DOI references without prefix without updating the libgin library;
+		// this code snippet can be removed if the corresponding libgin function
+		// (libgin.DataCite.AddReference) is updated and a new library version is released.
+		// This handling takes care of references containing only DOI URLs as well
+		// as improperly formatted DOI references entries that end with a proper DOI URL
+		// e.g: 'id: "doi:  https://doi.org/some-doi"'.
+		doiSplit := "https://doi.org/"
+		for idx, ref := range dataciteContent.References {
+			if strings.Contains(ref.ID, doiSplit) {
+				fmt.Printf("Updating DOI reference ID %q\n", ref.ID)
+				doiID := strings.Split(ref.ID, doiSplit)
+				dataciteContent.References[idx].ID = fmt.Sprintf("doi:%s", doiID[1])
+			}
+		}
+
 		datacite := libgin.NewDataCiteFromYAML(dataciteContent)
 
 		// Create storage directory

--- a/cmd/gindoid/templaterender_test.go
+++ b/cmd/gindoid/templaterender_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"net/url"
 	"testing"
 
 	"github.com/G-Node/libgin/libgin"
@@ -31,8 +32,20 @@ func TestRequestPageTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to parse DOIInfo, RequestPage templates: %s", err.Error())
 	}
+
+	// create local test file server
+	server := serveDataciteServer()
+	defer server.Close()
+
+	// check local test server works
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Could not parse server URL: %q", serverURL)
+	}
+
 	// read datacite.yml template for test
-	infoyml, err := readFileAtURL("https://gin.g-node.org/G-Node/Info/raw/master/datacite.yml")
+	infoURL := fmt.Sprintf("%s/reference-dc-yml", server.URL)
+	infoyml, err := readFileAtURL(infoURL)
 	if err != nil {
 		t.Fatalf("Failed to retrieve datacite.yml from GIN")
 	}
@@ -108,9 +121,19 @@ func TestLandingPageTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to parse DOIInfo, LandingPage templates: %s", err.Error())
 	}
+	// create local test file server
+	server := serveDataciteServer()
+	defer server.Close()
+
+	// check local test server works
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Could not parse server URL: %q", serverURL)
+	}
 
 	// read datacite.yml template for test
-	infoyml, err := readFileAtURL("https://gin.g-node.org/G-Node/Info/raw/master/datacite.yml")
+	infoURL := fmt.Sprintf("%s/reference-dc-yml", server.URL)
+	infoyml, err := readFileAtURL(infoURL)
 	if err != nil {
 		t.Fatalf("Failed to retrieve datacite.yml from GIN")
 	}
@@ -136,9 +159,19 @@ func TestKeywordIndexTemplate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to parse KeywordIndex templates: %s", err.Error())
 	}
+	// create local test file server
+	server := serveDataciteServer()
+	defer server.Close()
+
+	// check local test server works
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Could not parse server URL: %q", serverURL)
+	}
 
 	// read datacite.yml template for test
-	infoyml, err := readFileAtURL("https://gin.g-node.org/G-Node/Info/raw/master/datacite.yml")
+	infoURL := fmt.Sprintf("%s/reference-dc-yml", server.URL)
+	infoyml, err := readFileAtURL(infoURL)
 	if err != nil {
 		t.Fatalf("Failed to retrieve datacite.yml from GIN")
 	}
@@ -173,8 +206,19 @@ func TestKeywordTemplate(t *testing.T) {
 		t.Fatalf("Failed to parse Keyword templates: %s", err.Error())
 	}
 
+	// create local test file server
+	server := serveDataciteServer()
+	defer server.Close()
+
+	// check local test server works
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Could not parse server URL: %q", serverURL)
+	}
+
 	// read datacite.yml template for test
-	infoyml, err := readFileAtURL("https://gin.g-node.org/G-Node/Info/raw/master/datacite.yml")
+	infoURL := fmt.Sprintf("%s/reference-dc-yml", server.URL)
+	infoyml, err := readFileAtURL(infoURL)
 	if err != nil {
 		t.Fatalf("Failed to retrieve datacite.yml from GIN")
 	}

--- a/cmd/gindoid/testutils.go
+++ b/cmd/gindoid/testutils.go
@@ -204,6 +204,13 @@ func serveDataciteServer() *httptest.Server {
 			fmt.Printf("could not write valid response: %q", err.Error())
 		}
 	})
+	mux.HandleFunc("/test/src/master/.gitmodules", func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		_, err := rw.Write([]byte("OK"))
+		if err != nil {
+			fmt.Printf("could not write valid response: %q", err.Error())
+		}
+	})
 
 	return httptest.NewServer(mux)
 }

--- a/cmd/gindoid/testutils.go
+++ b/cmd/gindoid/testutils.go
@@ -77,6 +77,88 @@ title: "Doi test"
 templateversion: 1.2
 `
 
+const referenceDataciteYML = `# Metadata for DOI registration according to DataCite Metadata Schema 4.1.
+# For detailed schema description see https://doi.org/10.5438/0014
+
+## Required fields
+
+# The main researchers involved. Include digital identifier (e.g., ORCID)
+# if possible, including the prefix to indicate its type.
+authors:
+  -
+    firstname: "GivenName1"
+    lastname: "FamilyName1"
+    affiliation: "Affiliation1"
+    id: "ORCID:0000-0001-2345-6789"
+  -
+    firstname: "GivenName2"
+    lastname: "FamilyName2"
+    affiliation: "Affiliation2"
+    id: "ResearcherID:X-1234-5678"
+  -
+    firstname: "GivenName3"
+    lastname: "FamilyName3"
+
+# A title to describe the published resource.
+title: "Example Title"
+
+# Additional information about the resource, e.g., a brief abstract.
+description: |
+  Example description
+  that can contain linebreaks
+  but has to maintain indentation.
+
+# Lit of keywords the resource should be associated with.
+# Give as many keywords as possible, to make the resource findable.
+keywords:
+  - Neuroscience
+  - Keyword2
+  - Keyword3
+
+# License information for this resource. Please provide the license name and/or a link to the license.
+# Please add also a corresponding LICENSE file to the repository.
+license:
+  name: "Creative Commons CC0 1.0 Public Domain Dedication"
+  url: "https://creativecommons.org/publicdomain/zero/1.0/"
+
+
+
+## Optional Fields
+
+# Funding information for this resource.
+# Separate funder name and grant number by comma.
+funding:
+  - "DFG, AB1234/5-6"
+  - "EU, EU.12345"
+
+
+# Related publications. reftype might be: IsSupplementTo, IsDescribedBy, IsReferencedBy.
+# Please provide digital identifier (e.g., DOI) if possible.
+# Add a prefix to the ID, separated by a colon, to indicate the source.
+# Supported sources are: DOI, arXiv, PMID
+# In the citation field, please provide the full reference, including title, authors, journal etc.
+references:
+  -
+    id: "doi:10.xxx/zzzz"
+    reftype: "IsSupplementTo"
+    citation: "Citation1"
+  -
+    id: "arxiv:mmmm.nnnn"
+    reftype: "IsSupplementTo"
+    citation: "Citation2"
+  -
+    id: "pmid:nnnnnnnn"
+    reftype: "IsReferencedBy"
+    citation: "Citation3"
+
+
+# Resource type. Default is Dataset, other possible values are Software, Image, Text.
+resourcetype: Dataset
+
+# Do not edit or remove the following line
+templateversion: 1.2
+`
+
 // serveDataciteserver provides a local test server for Datacite xml handling
 func serveDataciteServer() *httptest.Server {
 	mux := http.NewServeMux()
@@ -111,6 +193,13 @@ func serveDataciteServer() *httptest.Server {
 	mux.HandleFunc("/dc-yml", func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 		_, err := rw.Write([]byte(validTestDataciteYML))
+		if err != nil {
+			fmt.Printf("could not write valid response: %q", err.Error())
+		}
+	})
+	mux.HandleFunc("/reference-dc-yml", func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		_, err := rw.Write([]byte(referenceDataciteYML))
 		if err != nil {
 			fmt.Printf("could not write valid response: %q", err.Error())
 		}

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -130,6 +130,7 @@ func EscXML(txt string) string {
 
 // ReferenceDescription creates a string representation of a reference for use in the XML description tag.
 // This is a utility function for the doi.xml template.
+// This function appears to be unused.
 func ReferenceDescription(ref libgin.Reference) string {
 	var namecitation string
 	if ref.Name != "" && ref.Citation != "" {
@@ -147,6 +148,7 @@ func ReferenceDescription(ref libgin.Reference) string {
 
 // ReferenceSource splits the source type from a reference string of the form <source>:<ID>
 // This is a utility function for the doi.xml template.
+// This function appears to be unused.
 func ReferenceSource(ref libgin.Reference) string {
 	idparts := strings.SplitN(ref.ID, ":", 2)
 	if len(idparts) != 2 {
@@ -159,6 +161,7 @@ func ReferenceSource(ref libgin.Reference) string {
 
 // ReferenceID splits the ID from a reference string of the form <source>:<ID>
 // This is a utility function for the doi.xml template.
+// This function appears to be unused.
 func ReferenceID(ref libgin.Reference) string {
 	idparts := strings.SplitN(ref.ID, ":", 2)
 	if len(idparts) != 2 {

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -565,7 +565,7 @@ func OldVersionLink(md *libgin.RepositoryMetadata) template.HTML {
 }
 
 // GINServerURL is the default template function returning
-// the main GIN server URL.  This function can be overriden
+// the main GIN server URL.  This function can be overridden
 // before calling HTML template execution to provide a different
 // GIN server instance URL.
 func GINServerURL() string {

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -455,9 +455,20 @@ func FormatReferences(md *libgin.RepositoryMetadata) []libgin.Reference {
 }
 
 // FormatCitation returns the formatted citation string for a given dataset.
+// Returns an empty string if the input is not fully initialized.
 func FormatCitation(md *libgin.RepositoryMetadata) string {
+	if md == nil || md.DataCite == nil {
+		log.Printf("FormatCitation: encountered libgin.RepositoryMetadata nil pointer: %v", md)
+		return ""
+	}
+
 	authors := FormatAuthorList(md)
-	return fmt.Sprintf("%s (%d) %s. G-Node. https://doi.org/%s", authors, md.Year, md.Titles[0], md.Identifier.ID)
+	var title string
+	if len(md.Titles) > 0 {
+		title = md.Titles[0]
+	}
+
+	return fmt.Sprintf("%s (%d) %s. G-Node. https://doi.org/%s", authors, md.Year, title, md.Identifier.ID)
 }
 
 // FormatIssuedDate returns the issued date of the dataset in the format DD Mon.

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -128,50 +128,6 @@ func EscXML(txt string) string {
 	return buf.String()
 }
 
-// ReferenceDescription creates a string representation of a reference for use in the XML description tag.
-// This is a utility function for the doi.xml template.
-// This function appears to be unused.
-func ReferenceDescription(ref libgin.Reference) string {
-	var namecitation string
-	if ref.Name != "" && ref.Citation != "" {
-		namecitation = ref.Name + " " + ref.Citation
-	} else {
-		namecitation = ref.Name + ref.Citation
-	}
-
-	if !strings.HasSuffix(namecitation, ".") {
-		namecitation += "."
-	}
-	refDesc := fmt.Sprintf("%s: %s (%s)", ref.RefType, namecitation, ref.ID)
-	return EscXML(refDesc)
-}
-
-// ReferenceSource splits the source type from a reference string of the form <source>:<ID>
-// This is a utility function for the doi.xml template.
-// This function appears to be unused.
-func ReferenceSource(ref libgin.Reference) string {
-	idparts := strings.SplitN(ref.ID, ":", 2)
-	if len(idparts) != 2 {
-		// Malformed ID (no colon)
-		// No source type
-		return ""
-	}
-	return EscXML(idparts[0])
-}
-
-// ReferenceID splits the ID from a reference string of the form <source>:<ID>
-// This is a utility function for the doi.xml template.
-// This function appears to be unused.
-func ReferenceID(ref libgin.Reference) string {
-	idparts := strings.SplitN(ref.ID, ":", 2)
-	if len(idparts) != 2 {
-		// Malformed ID (no colon)
-		// No source type
-		return EscXML(idparts[0])
-	}
-	return EscXML(idparts[1])
-}
-
 // GetGINURL returns the full URL to the configured GIN server. If it's
 // configured with a non-standard port, the port number is included.
 func GetGINURL(conf *Configuration) string {

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -313,3 +313,33 @@ func TestFormatCitation(t *testing.T) {
 		t.Fatalf("Expected different citation: %q", cit)
 	}
 }
+
+func TestURLexists(t *testing.T) {
+	// Start local test server
+	server := serveDataciteServer()
+	// Close the server when test finishes
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Could not parse server URL: %q", serverURL)
+	}
+
+	// test non-existing URL
+	uex := URLexists("i/do/not/exist")
+	if uex {
+		t.Fatal("Expected false on non-existing URL")
+	}
+
+	// test invalid URL
+	uex = URLexists(fmt.Sprintf("%s/not-there", server.URL))
+	if uex {
+		t.Fatal("Expected false on invalid URL")
+	}
+
+	// test valid URL
+	uex = URLexists(fmt.Sprintf("%s/xml", server.URL))
+	if !uex {
+		t.Fatal("Expected true on valid URL")
+	}
+}

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -292,3 +292,24 @@ func TestFormatAuthorList(t *testing.T) {
 		t.Fatalf("Expected formatted authors string 'NameA G, NameB, NameC GGG' but got: %s", authors)
 	}
 }
+
+func TestFormatCitation(t *testing.T) {
+	// assert no issue on blank input
+	md := new(libgin.RepositoryMetadata)
+	cit := FormatCitation(md)
+	if cit != "" {
+		t.Fatalf("Expected empty citation: %q", cit)
+	}
+
+	// author format is tested in its own function
+	md.DataCite = &libgin.DataCite{
+		Year:   1996,
+		Titles: []string{"test-title"},
+		Identifier: libgin.Identifier{
+			ID: "test-id"},
+	}
+	cit = FormatCitation(md)
+	if cit != " (1996) test-title. G-Node. https://doi.org/test-id" {
+		t.Fatalf("Expected different citation: %q", cit)
+	}
+}

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -18,7 +18,7 @@ import (
 func TestReadFileAtPath(t *testing.T) {
 	_, err := readFileAtPath("I/do/not/exist")
 	if err == nil {
-		t.Fatal("Missing error opening non existant file.")
+		t.Fatal("Missing error opening non existent file.")
 	}
 
 	tmpDir, err := ioutil.TempDir("", "test_gindoi_licfromfile")
@@ -46,7 +46,7 @@ func TestReadFileAtPath(t *testing.T) {
 func TestReadFileAtURL(t *testing.T) {
 	_, err := readFileAtURL("https://I/do/not/exist")
 	if err == nil {
-		t.Fatal("Missing error opening non existant URL.")
+		t.Fatal("Missing error opening non existent URL.")
 	}
 
 	mux := http.NewServeMux()
@@ -245,12 +245,12 @@ func TestFormatAuthorList(t *testing.T) {
 	md := new(libgin.RepositoryMetadata)
 	authors := FormatAuthorList(md)
 	if authors != "" {
-		t.Fatalf("Expected emtpy string but got: %s", authors)
+		t.Fatalf("Expected empty string but got: %s", authors)
 	}
 	md.DataCite = &libgin.DataCite{}
 	authors = FormatAuthorList(md)
 	if authors != "" {
-		t.Fatalf("Expected emtpy string but got: %s", authors)
+		t.Fatalf("Expected empty string but got: %s", authors)
 	}
 
 	// Test single author, no comma, whitespace trim

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -343,3 +343,33 @@ func TestURLexists(t *testing.T) {
 		t.Fatal("Expected true on valid URL")
 	}
 }
+
+func TestHasGitModules(t *testing.T) {
+	// Start local test server
+	server := serveDataciteServer()
+	// Close the server when test finishes
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("Could not parse server URL: %q", serverURL)
+	}
+
+	// test non-existing URL
+	uex := HasGitModules("i/do/not", "exist")
+	if uex {
+		t.Fatal("Expected false on non-existing URL")
+	}
+
+	// test invalid URL
+	uex = HasGitModules(server.URL, "not/there")
+	if uex {
+		t.Fatal("Expected false on invalid URL")
+	}
+
+	// test valid URL
+	uex = HasGitModules(server.URL, "test")
+	if !uex {
+		t.Fatal("Expected true on valid URL")
+	}
+}

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -174,7 +174,7 @@ func TestLicenseWarnings(t *testing.T) {
 		t.Fatalf("Unexpected warnings(%d): %v", len(checkwarn), checkwarn)
 	}
 	if !strings.Contains(checkwarn[0], "License URL (datacite) not found: ''") {
-		t.Fatalf("Missing unkown license URL warning: %v", checkwarn)
+		t.Fatalf("Missing unknown license URL warning: %v", checkwarn)
 	}
 	if !strings.Contains(checkwarn[1], "License name (datacite) not found: ''") {
 		t.Fatalf("Missing unknown license name warning: %v", checkwarn)

--- a/cmd/gindoid/validation_test.go
+++ b/cmd/gindoid/validation_test.go
@@ -305,24 +305,6 @@ func TestAuthorWarnings(t *testing.T) {
 		t.Fatalf("Expected empty researcherid value message: %v", checkwarn[0])
 	}
 
-	// Check warning on false author ID entries
-	yada.Authors[0].ID = "orcid:x000-0001-2345-6789"
-	checkwarn = authorWarnings(yada, warnings)
-	if len(checkwarn) != 1 {
-		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)
-	}
-	if !strings.Contains(checkwarn[0], "ID was not found at the ID service") {
-		t.Fatalf("Expected not found ID message: %v", checkwarn[0])
-	}
-	yada.Authors[0].ID = "researcherID:x-1234-5678"
-	checkwarn = authorWarnings(yada, warnings)
-	if len(checkwarn) != 1 {
-		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)
-	}
-	if !strings.Contains(checkwarn[0], "ID was not found at the ID service") {
-		t.Fatalf("Expected not found ID message: %v", checkwarn[0])
-	}
-
 	// Check warning on duplicate ORCID, researchID
 	yada.Authors[0].ID = "orcid:0000-0001-6744-1159"
 	auth = yada.Authors
@@ -349,6 +331,45 @@ func TestAuthorWarnings(t *testing.T) {
 	checkwarn = authorWarnings(yada, warnings)
 	if len(checkwarn) != 0 {
 		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)
+	}
+}
+
+func TestAuthorIDWarnings(t *testing.T) {
+	var warnings []string
+	yada := &libgin.RepositoryYAML{}
+
+	// Check no author warning on empty struct or empty Author
+	checkwarn := authorIDWarnings(yada, warnings)
+	if len(checkwarn) != 0 {
+		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)
+	}
+
+	var auth []libgin.Author
+	auth = append(auth, libgin.Author{})
+	yada.Authors = auth
+
+	checkwarn = authorIDWarnings(yada, warnings)
+	if len(checkwarn) != 0 {
+		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)
+	}
+
+	// Check warning on false author ID entries
+	yada.Authors[0].ID = "orcid:x000-0001-2345-6789"
+	checkwarn = authorIDWarnings(yada, warnings)
+	if len(checkwarn) != 1 {
+		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)
+	}
+	if !strings.Contains(checkwarn[0], "ID was not found at the ID service") {
+		t.Fatalf("Expected not found ID message: %v", checkwarn[0])
+	}
+
+	yada.Authors[0].ID = "researcherID:x-1234-5678"
+	checkwarn = authorIDWarnings(yada, warnings)
+	if len(checkwarn) != 1 {
+		t.Fatalf("Invalid number of messages(%d): %v", len(checkwarn), checkwarn)
+	}
+	if !strings.Contains(checkwarn[0], "ID was not found at the ID service") {
+		t.Fatalf("Expected not found ID message: %v", checkwarn[0])
 	}
 }
 

--- a/templates/checklist.go
+++ b/templates/checklist.go
@@ -37,6 +37,10 @@ const ChecklistFile = `# Part 1 - pre registration
 - on the DOI server ({{ .CL.Doiserver }}) make sure all information has been properly downloaded 
   to the staging directory and all annex files are unlocked and the content is present:
     -[ ] {{ .CL.Dirdoiprep }}/annexcheck {{ .SemiDOIDirpath }}
+    - identify "normal" git annex issues e.g. locked or missing annex content
+    -[ ] cd {{ .SemiDOICleanup }}/{{ .RepoLower }}
+    -[ ] gin git annex find --locked
+    -[ ] gin git annex find --not --in=here
     -[ ] find {{ .SemiDOICleanup }} -type l -print
     -[ ] find {{ .SemiDOICleanup }} -type f -size -100c -print0 | xargs -0 grep -i annex.objects
     -[ ] grep annex.objects $(find {{ .SemiDOICleanup }} -type f -size -100c -print)
@@ -45,6 +49,10 @@ const ChecklistFile = `# Part 1 - pre registration
          file does not contain all required data. Run the next steps - the script will
          download all missing information and upload to the DOI fork. When recreating the
          zip file, all files will be manually unlocked first.
+    - approximate the required zip size via the git annex file size and the repository size
+    -[ ] gin git annex info --fast .
+    -[ ] du -chL --exclude=.git* .
+    -[ ] ls -lahrt  {{ .CL.Dirdoi }}/10.12751/g-node.{{ .CL.Regid }}/
     - check the DOI directory content
       -[ ] zip file created in {{ .CL.Dirdoi }}/10.12751/g-node.{{ .CL.Regid }}
       -[ ] check zip file content
@@ -129,6 +137,10 @@ const ChecklistFile = `# Part 1 - pre registration
 -[ ] check downloaded data; if any of the checks fail, the DOI fork has to be deleted and the 
      process repeated after the issue has been addressed
     -[ ] {{ .CL.Dirdoiprep }}/annexcheck {{ .CL.Dirdoiprep }}/{{ .CL.Repo }}
+    - identify "normal" git annex issues e.g. locked or missing annex content
+    -[ ] cd {{ .CL.Dirdoiprep }}/{{ .CL.Repo }}
+    -[ ] gin git annex find --locked
+    -[ ] gin git annex find --not --in=here
     -[ ] find {{ .CL.Dirdoiprep }}/{{ .CL.Repo }} -type l -print
     -[ ] find {{ .CL.Dirdoiprep }}/{{ .CL.Repo }} -type f -size -100c -print0 | xargs -0 grep -i annex.objects
     -[ ] grep annex.objects $(find {{ .CL.Dirdoiprep }}/{{ .CL.Repo }} -type f -size -100c -print)
@@ -140,6 +152,12 @@ const ChecklistFile = `# Part 1 - pre registration
 -[ ] create DOI zip file
     - screen -r {{ .FullDOIScreenID }}
     - sudo ./makezip {{ .RepoLower }} > {{ .Ziplog }}
+
+- approximate the required zip size via the git annex file size and the repository size and compare to the created zip size
+    -[ ] cd {{ .CL.Dirdoiprep }}/{{ .CL.Repo }}
+    -[ ] gin git annex info --fast .
+    -[ ] du -chL --exclude=.git* .
+    -[ ] ls -lahrt {{ .CL.Dirdoiprep }}/{{ .CL.Repo }}/*.zip
 
 -[ ] make sure there is no zip file in the target directory left 
      from the previous registration process.


### PR DESCRIPTION
This PR adds a couple of updates, fixes and tests
- reference IDs containing "https://doi.org/provided-id" are now allowed and parsed into the supported format "id: DOI:provided-id". To permit DOI references without prefix without updating the libgin function libgin.DataCite.AddReference the DataCite reference is updated before writing the DOI XML file in both `web.startDOIRegistration` and `genxml`. This code can be removed when an appropriately updated version of libgin is available.
- validation author ID checks to the external services ORCID and Publons were moved to their own function `authorIDWarnings`. This should make the external dependency clearer and also reduce testing times for the refactored tests.
- the `checklist` template has been updated to include repository size checks. 
- the unused `util` functions `ReferenceDescription`, `ReferenceSource` and `ReferenceID` were removed.
- go template tests were refactored to reduce external dependencies: By locally serving datacite.yml files to test go template
rendering instead of loading a datacite.yml file from the live gin server, the overall test times can be noticeably reduced and removes an external dependency.
- tests for the utils functions `FormatCitation`, `URLexists` and `hasGitModules` were added.