### PR TITLE
Git Annex content safeguards: missing and locked content handling

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -53,6 +53,8 @@ jobs:
           bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
           sudo apt-get update -qq
           sudo apt-get install git-annex-standalone
+          git version
+          git annex version
       - name: Show Go version
         run: go version
       - name: Fetch dependencies
@@ -74,6 +76,8 @@ jobs:
           bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
           sudo apt-get update -qq
           sudo apt-get install git-annex-standalone
+          git version
+          git annex version
       - name: Fetch dependencies
         run: |
           go get -d ./...

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -48,6 +48,11 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.15'
+      - name: Install git annex dependency
+        run: |
+          bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+          sudo apt-get update -qq
+          sudo apt-get install git-annex-standalone
       - name: Show Go version
         run: go version
       - name: Fetch dependencies
@@ -64,6 +69,11 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: '1.15'
+      - name: Install git annex dependency
+        run: |
+          bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
+          sudo apt-get update -qq
+          sudo apt-get install git-annex-standalone
       - name: Fetch dependencies
         run: |
           go get -d ./...

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -408,8 +408,8 @@ func cloneRepo(URI string, destdir string, conf *Configuration) error {
 	for stat := range downloadchan {
 		log.Print(stat)
 		if stat.Err != nil {
-			log.Printf("Repository cloning failed during annex get: %s", stat.Err)
-			return stat.Err
+			log.Printf("Repository cloning failed during annex get: %s, %s", stat.FileName, stat.Err)
+			return fmt.Errorf("annex content of %q: %q", stat.FileName, stat.Err)
 		}
 	}
 
@@ -421,8 +421,8 @@ func cloneRepo(URI string, destdir string, conf *Configuration) error {
 	for stat := range downloadchan {
 		log.Print(stat)
 		if stat.Err != nil {
-			log.Printf("Repository cloning failed during annex get: %s", stat.Err)
-			return stat.Err
+			log.Printf("Repository cloning failed during annex get: %s, %s", stat.FileName, stat.Err)
+			return fmt.Errorf("annex content of %q: %q", stat.FileName, stat.Err)
 		}
 	}
 	return nil

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -581,3 +581,25 @@ func annexAvailable() (bool, error) {
 	}
 	return true, nil
 }
+
+// remoteGitCMD runs a git command for a given directory
+// If the useannex flag is set to true, the executed command
+// will be a git annex command instead of a regular git command.
+func remoteGitCMD(gitdir string, useannex bool, gitcmd ...string) (string, string, error) {
+	if _, err := os.Stat(gitdir); os.IsNotExist(err) {
+		return "", "", fmt.Errorf("path not found %q", gitdir)
+	}
+
+	cmdstr := append([]string{"git", "-C", gitdir}, gitcmd...)
+	cmd := gingit.Command("version")
+	cmd.Args = cmdstr
+	if useannex {
+		cmdstr = append([]string{"git", "-C", gitdir, "annex"}, gitcmd...)
+		cmd = gingit.AnnexCommand("version")
+		cmd.Args = cmdstr
+	}
+	fmt.Printf("using command: %v, %v\n", gitcmd, cmdstr)
+	stdout, stderr, err := cmd.OutputError()
+
+	return string(stdout), string(stderr), err
+}

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -600,7 +600,7 @@ func remoteGitCMD(gitdir string, useannex bool, gitcmd ...string) (string, strin
 		cmd = gingit.AnnexCommand("version")
 		cmd.Args = cmdstr
 	}
-	fmt.Printf("using command: %v, %v\n", gitcmd, cmdstr)
+	log.Printf("remoteGitCMD: %v", cmdstr)
 	stdout, stderr, err := cmd.OutputError()
 
 	return string(stdout), string(stderr), err

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -621,3 +621,21 @@ func missingAnnexContent(gitdir string) (bool, string, error) {
 	}
 	return true, string(stdout), nil
 }
+
+func lockedAnnexContent(gitdir string) (bool, string, error) {
+	if _, err := os.Stat(gitdir); os.IsNotExist(err) {
+		return false, "", fmt.Errorf("path not found %q", gitdir)
+	}
+	// command should not return with an error or with any stderr content
+	// If stdout is empty, there is no locked content. If it is not empty,
+	// the number of lines correspond to the number of files with locked content.
+	stdout, stderr, err := remoteGitCMD(gitdir, true, "find", "--locked")
+	if err != nil {
+		return false, "", err
+	} else if string(stderr) != "" {
+		return false, "", fmt.Errorf("git annex error: %s", string(stderr))
+	} else if string(stdout) == "" {
+		return false, "", nil
+	}
+	return true, string(stdout), nil
+}

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -603,3 +603,21 @@ func remoteGitCMD(gitdir string, useannex bool, gitcmd ...string) (string, strin
 
 	return string(stdout), string(stderr), err
 }
+
+func missingAnnexContent(gitdir string) (bool, string, error) {
+	if _, err := os.Stat(gitdir); os.IsNotExist(err) {
+		return false, "", fmt.Errorf("path not found %q", gitdir)
+	}
+	// command should not return with an error or with any stderr content
+	// If stdout is empty, there is no missing content. If it is not empty,
+	// the number of lines correspond to the number of files with missing content.
+	stdout, stderr, err := remoteGitCMD(gitdir, true, "find", "--not", "--in=here")
+	if err != nil {
+		return false, "", err
+	} else if string(stderr) != "" {
+		return false, "", fmt.Errorf("git annex error: %s", string(stderr))
+	} else if string(stdout) == "" {
+		return false, "", nil
+	}
+	return true, string(stdout), nil
+}

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -639,3 +639,25 @@ func lockedAnnexContent(gitdir string) (bool, string, error) {
 	}
 	return true, string(stdout), nil
 }
+
+func annexSize(gitdir string) (string, error) {
+	if _, err := os.Stat(gitdir); os.IsNotExist(err) {
+		return "", fmt.Errorf("path not found %q", gitdir)
+	}
+	// command should not return with an error or with any stderr content
+	stdout, stderr, err := remoteGitCMD(gitdir, true, "info", "--fast", ".")
+	if err != nil {
+		return "", err
+	} else if string(stderr) != "" {
+		return "", fmt.Errorf("git annex error: %s", string(stderr))
+	} else if string(stdout) == "" {
+		return "", nil
+	}
+
+	// annex should return the total size of files in the working tree
+	splitsizes := strings.Split(stdout, "size of annexed files in working tree: ")
+	if len(splitsizes) != 2 {
+		return "", nil
+	}
+	return strings.TrimSpace(splitsizes[1]), nil
+}

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -606,6 +606,14 @@ func remoteGitCMD(gitdir string, useannex bool, gitcmd ...string) (string, strin
 	return string(stdout), string(stderr), err
 }
 
+// missingAnnexContent checks the annex content of a provided local
+// git annex repository for missing annex file content. If locally missing
+// file content is identified, the function returns true and a list of all
+// files with missing content separated by the newline character "\n" as
+// a single string.
+// If no missing content is found, the function returns false and an empty
+// string. If any issue occurs during processing, the function will return
+// false, an empty string and an appropriate error.
 func missingAnnexContent(gitdir string) (bool, string, error) {
 	if _, err := os.Stat(gitdir); os.IsNotExist(err) {
 		return false, "", fmt.Errorf("path not found %q", gitdir)
@@ -624,6 +632,13 @@ func missingAnnexContent(gitdir string) (bool, string, error) {
 	return true, string(stdout), nil
 }
 
+// lockedAnnexContent checks the annex content of a provided local
+// git annex repository for locked annex files. If locked files can
+// be identified, the function returns true and a list of all found
+// locked files separated by the newline character "\n" as a single string.
+// If no locked files are found, the function returns false and an empty
+// string. If any issue occurs during processing, the function will return
+// false, an empty string and an appropriate error.
 func lockedAnnexContent(gitdir string) (bool, string, error) {
 	if _, err := os.Stat(gitdir); os.IsNotExist(err) {
 		return false, "", fmt.Errorf("path not found %q", gitdir)
@@ -642,6 +657,11 @@ func lockedAnnexContent(gitdir string) (bool, string, error) {
 	return true, string(stdout), nil
 }
 
+// annexSize parses the annex content size from a local git annex
+// repository and returns a trimmed string containing size and unit
+// in the format "[size in float] [fully spelled unit]bytes"
+// e.g. "12.2 gigabytes". If any issue occurs while parsing the
+// annex content size, the function returns with an appropriate error.
 func annexSize(gitdir string) (string, error) {
 	if _, err := os.Stat(gitdir); os.IsNotExist(err) {
 		return "", fmt.Errorf("path not found %q", gitdir)
@@ -664,6 +684,14 @@ func annexSize(gitdir string) (string, error) {
 	return strings.TrimSpace(splitsizes[1]), nil
 }
 
+// unlockAnnexClone receives a directory of a git annex repository containing
+// locked annex content, the name of the repository and an output directory.
+// The function creates a local clone and annex file copy  of the primary
+// git annex content in the output directory and unlocks all annex files in
+// the secondary git annex repository.
+// When the process is successful, the full directory path of the secondary
+// repository is returned, otherwise the function ends with an appropriate
+// error.
 func unlockAnnexClone(reponame, gitcloneroot, gitrepodir string) (string, error) {
 	clonename := fmt.Sprintf("%s_unlocked", reponame)
 	clonedir := filepath.Join(gitcloneroot, clonename)
@@ -724,6 +752,13 @@ func unlockAnnexClone(reponame, gitcloneroot, gitrepodir string) (string, error)
 	return clonedir, nil
 }
 
+// acceptedAnnexSize parses a string containing git annex style formatted
+// repository size in the format "[size in float] [fully spelled unit]bytes"
+// e.g. "12.2 gigabytes".
+// If the string can be properly parsed, the provided unit is supported
+// and the size is below the supported threshold (currently 100.0 gigabytes)
+// the function returns true. In any other case including parsing issues,
+// the function returns false.
 func acceptedAnnexSize(annexSize string) bool {
 	// acceptedGigaSize might be moved outside to become a server setting
 	acceptedGigaSize := 100.0

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -667,7 +667,7 @@ func annexSize(gitdir string) (string, error) {
 func unlockAnnexClone(reponame, gitcloneroot, gitrepodir string) (string, error) {
 	clonename := fmt.Sprintf("%s_unlocked", reponame)
 	clonedir := filepath.Join(gitcloneroot, clonename)
-	log.Printf("[Annex unlock] cloning %s to dir %s", gitrepodir, clonedir)
+	log.Printf("unlockAnnex: cloning %s to dir %s", gitrepodir, clonedir)
 
 	// Clone annex repository to specified clone directory
 	// Git clone outputs everything to stderr
@@ -675,7 +675,7 @@ func unlockAnnexClone(reponame, gitcloneroot, gitrepodir string) (string, error)
 	if err != nil {
 		return "", fmt.Errorf("error cloning annex repo %s: %q, %q", gitrepodir, err.Error(), stderr)
 	}
-	log.Printf("[Annex unlock] clone done: %q, %q", stdout, stderr)
+	log.Printf("unlockAnnex: clone done: %q, %q", stdout, stderr)
 
 	// Make sure the git user credentials have been set; otherwise git annex copy will fail
 	_, stderr, err = remoteGitCMD(clonedir, false, "config", "user.name", "GIN-DOI-service-user")
@@ -694,7 +694,7 @@ func unlockAnnexClone(reponame, gitcloneroot, gitrepodir string) (string, error)
 	} else if stderr != "" {
 		return "", fmt.Errorf("error output on local annex (%s) content copy: %q", clonedir, stderr)
 	}
-	log.Printf("[Annex unlock] local copy finished %q", stdout)
+	log.Printf("unlockAnnex: local copy finished %q", stdout)
 
 	// re-check missing annex content in clone directory; should be false
 	hasmissing, missinglist, err := missingAnnexContent(clonedir)
@@ -711,7 +711,7 @@ func unlockAnnexClone(reponame, gitcloneroot, gitrepodir string) (string, error)
 	} else if stderr != "" {
 		return "", fmt.Errorf("error unlocking files on local copy (%s): %q", clonedir, stderr)
 	}
-	log.Printf("[Annex unlock] Files unlocked in clone directory: %q", stdout)
+	log.Printf("unlockAnnex: Files unlocked in clone directory: %q", stdout)
 
 	// re-check locked content
 	haslocked, lockedlist, err := lockedAnnexContent(clonedir)

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -672,14 +672,12 @@ func annexSize(gitdir string) (string, error) {
 		return "", err
 	} else if string(stderr) != "" {
 		return "", fmt.Errorf("git annex error: %s", string(stderr))
-	} else if string(stdout) == "" {
-		return "", nil
 	}
 
 	// annex should return the total size of files in the working tree
 	splitsizes := strings.Split(stdout, "size of annexed files in working tree: ")
 	if len(splitsizes) != 2 {
-		return "", nil
+		return "", fmt.Errorf("could not properly parse annex size: %q", stdout)
 	}
 	return strings.TrimSpace(splitsizes[1]), nil
 }

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -566,3 +566,18 @@ func annexCMD(annexargs ...string) (string, string, error) {
 
 	return string(stdout), string(stderr), err
 }
+
+// annexAvailable checks whether annex is available to the gin client library.
+// The function returns false with no error, if the annex command execution
+// ends with the git message that 'annex' is not a git command.
+// It will return false and the error message on any different error.
+func annexAvailable() (bool, error) {
+	_, stderr, err := annexCMD("version")
+	if err != nil {
+		if strings.Contains(stderr, "'annex' is not a git command") {
+			return false, nil
+		}
+		return false, fmt.Errorf("%s, %s", stderr, err.Error())
+	}
+	return true, nil
+}

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	gingit "github.com/G-Node/gin-cli/git"
 	gdtmpl "github.com/G-Node/gin-doi/templates"
 	"github.com/G-Node/libgin/libgin"
 )
@@ -554,4 +555,14 @@ func HasGitModules(ginurl string, repo string) bool {
 	log.Printf("HasGitModules: checking url %s", moduleurl)
 
 	return URLexists(moduleurl)
+}
+
+// annexCMD runs the passed git annex command arguments.
+// The command returns stdout and stderr as strings and any error that might occur.
+func annexCMD(annexargs ...string) (string, string, error) {
+	log.Printf("Running annex command: %s\n", annexargs)
+	cmd := gingit.AnnexCommand(annexargs...)
+	stdout, stderr, err := cmd.OutputError()
+
+	return string(stdout), string(stderr), err
 }

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -754,12 +754,12 @@ func unlockAnnexClone(reponame, gitcloneroot, gitrepodir string) (string, error)
 // repository size in the format "[size in float] [fully spelled unit]bytes"
 // e.g. "12.2 gigabytes".
 // If the string can be properly parsed, the provided unit is supported
-// and the size is below the supported threshold (currently 100.0 gigabytes)
+// and the size is below the supported threshold (currently 250.0 gigabytes)
 // the function returns true. In any other case including parsing issues,
 // the function returns false.
 func acceptedAnnexSize(annexSize string) bool {
 	// acceptedGigaSize might be moved outside to become a server setting
-	acceptedGigaSize := 100.0
+	acceptedGigaSize := 250.0
 
 	sizesplit := strings.Split(annexSize, " ")
 	if len(sizesplit) != 2 {

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -761,3 +761,44 @@ func TestUnlockAnnexClone(t *testing.T) {
 	targetpath := filepath.Join(targetroot, fmt.Sprintf("%s_unlocked", reponame))
 	defer remoteGitCMD(targetpath, true, "uninit", fpath)
 }
+
+func TestAcceptedAnnexSize(t *testing.T) {
+	// check empty string
+	if acceptedAnnexSize("") {
+		t.Fatal("True on empty string")
+	}
+
+	// check non-splitable string
+	if acceptedAnnexSize("100kilobytes") {
+		t.Fatal("True on invalid string")
+	}
+
+	// check unsupported 'unit'
+	if acceptedAnnexSize("10.4 petabytes") {
+		t.Fatal("True on unsupported unit petabytes")
+	}
+
+	// check supported units
+	if !acceptedAnnexSize("10.4 bytes") {
+		t.Fatal("False on bytes")
+	}
+	if !acceptedAnnexSize("10.4 kilobytes") {
+		t.Fatal("False on kilobytes")
+	}
+	if !acceptedAnnexSize("10.4 megabytes") {
+		t.Fatal("False on megabytes")
+	}
+
+	// check supported unit and supported size
+	if !acceptedAnnexSize("10.4 gigabytes") {
+		t.Fatal("False on allowed gigabytes")
+	}
+
+	// check supported unit and unsupported size
+	if acceptedAnnexSize("100.1 gigabytes") {
+		t.Fatal("True on unsupported size")
+	}
+	if acceptedAnnexSize("1 terabytes") {
+		t.Fatal("True on terabyte")
+	}
+}

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -373,3 +373,34 @@ func TestHasGitModules(t *testing.T) {
 		t.Fatal("Expected true on valid URL")
 	}
 }
+
+func TestRemoteGitCMD(t *testing.T) {
+	// check annex is available to the test; stop the test otherwise
+	hasAnnex, err := annexAvailable()
+	if err != nil {
+		t.Fatalf("Error checking git annex: %q", err.Error())
+	} else if !hasAnnex {
+		t.Skipf("Annex is not available, skipping test...\n")
+	}
+
+	targetpath := t.TempDir()
+
+	// check running git command from non existing path
+	_, _, err = remoteGitCMD("/I/do/no/exist", false, "version")
+	if err == nil {
+		t.Fatal("expected error on non existing directory")
+	} else if !strings.Contains(err.Error(), "") {
+		t.Fatalf("expected path not found error but got %q", err.Error())
+	}
+
+	// check running git command
+	stdout, stderr, err := remoteGitCMD(targetpath, false, "version")
+	if err != nil {
+		t.Fatalf("%q, %q, %q", err.Error(), stderr, stdout)
+	}
+	// check running git annex command
+	stdout, stderr, err = remoteGitCMD(targetpath, true, "version")
+	if err != nil {
+		t.Fatalf("%q, %q, %q", err.Error(), stderr, stdout)
+	}
+}

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -800,7 +800,7 @@ func TestAcceptedAnnexSize(t *testing.T) {
 	}
 
 	// check supported unit and unsupported size
-	if acceptedAnnexSize("100.1 gigabytes") {
+	if acceptedAnnexSize("250.1 gigabytes") {
 		t.Fatal("True on unsupported size")
 	}
 	if acceptedAnnexSize("1 terabytes") {

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -778,6 +778,11 @@ func TestAcceptedAnnexSize(t *testing.T) {
 		t.Fatal("True on unsupported unit petabytes")
 	}
 
+	// check non parseable size with threshold unit gigabytes
+	if acceptedAnnexSize("doesnotconverttofloat gigabytes") {
+		t.Fatal("True on non-parsable size")
+	}
+
 	// check supported units
 	if !acceptedAnnexSize("10.4 bytes") {
 		t.Fatal("False on bytes")

--- a/templates/checklist.go
+++ b/templates/checklist.go
@@ -37,6 +37,10 @@ const ChecklistFile = `# Part 1 - pre registration
 - on the DOI server ({{ .CL.Doiserver }}) make sure all information has been properly downloaded 
   to the staging directory and all annex files are unlocked and the content is present:
     -[ ] {{ .CL.Dirdoiprep }}/annexcheck {{ .SemiDOIDirpath }}
+    -[ ] if locked content has been found and unlocked by the doi-server, {{ .SemiDOICleanup }}
+         will contain a second folder named "{{ .RepoLower }}_unlocked". The zip file was created
+         with the content of this repository which should contain only unlocked files.
+         DO NOT USE the "unlocked" folder to upload to the DOI fork later on.
     - identify "normal" git annex issues e.g. locked or missing annex content
     -[ ] cd {{ .SemiDOICleanup }}/{{ .RepoLower }}
     -[ ] gin git annex find --locked


### PR DESCRIPTION
This PR introduces changes handling missing and locked annex content handling:
After downloading the annex content to a local repository a function checks the repository for missing annex content.
- if missing annex content can be identified, e.g. because the secondary download also silently failed and left a file with missing content, creating the zip file is skipped and the number of files with missing or locked content is reported to the admin via the "clone-report" email.
- if all annex content is locally available, but files are in a locked state, the git repository is checked for annex size. If the annex size is larger than 100 GB, the zip creation is skipped and the admin is informed. Such large repositories should then be handled manually to keep data space and time spent at a minimum.
- if the annex content is below 100 GB, the git annex repository is locally cloned to the same preparation directory as the primary git annex repository and all annex content is unlocked. The zip file is then created with the unlocked data while the git state of the primary repository remains unchanged and can be used to upload to the DOI repository clone.
This PR addresses the issues #74, #98 and #103.

Newly added functionality:
- the new `util.annexCMD` function allows running general git annex functions
- the new `util.annexAvailable` function checks whether git annex is currently available
- the new `util.remoteGitCMD` function allows to run any git or git annex command in a specified git repository without changing the current working directory. This should avoid directory errors as described in issue #104.
- the new `util.missingAnnexContent` function checks whether an existing git annex repository in a local directory has annex files with locally missing file content.
- the new `util.lockedAnnexContent` function checks whether a local git annex repository has locked annex content.
- the new `util.annexSize` function returns the git annex metadata file size of a local git annex repository.
- the new `util.unlockAnnexClone` function creates a local clone and annex file copy of another local git annex repository and unlocks all annex files in the secondary git annex repository.
- the new `util.acceptedAnnexSize` function checks via its annex metadata whether a local git annex directory is below a specified data content size; currently this cutoff is defined as 250 GB.
- tests for all new functions are added as well; annex specifics tests are skipped if annex is not available locally.
- gh actions is updated to include git annex to allow the annex specific tests to run

Updates of existing functions:
- after `dataset.cloneRepo` has finished cloning the git part of the repo but before fetching any annex content, the repository on the server is checked for missing annex content. If annex content is missing, the content download is skipped and an error message is returned.
- when one of the git annex content download in `dataset.cloneRepo` fails, the returned error message is now more specific and includes the name of the missing content file.
- when the cloning and zip creation process is finished, the admin "clone-report" email now contains the size of the repositories' annex content size and if available the created zip file size. The admin then has a rough estimation whether the zip file contains all data or not.
- the created "DOI checklist" template now contains a note with respect to a secondary "unlocked annex files" preparation repository.
