### PR TITLE
New live-server preparation

### DIFF
--- a/cmd/gindoid/config.go
+++ b/cmd/gindoid/config.go
@@ -56,6 +56,10 @@ type Configuration struct {
 		// format host:/path/)
 		XMLURL string
 	}
+	// LockedContentCutoffSize defines the git annex size above which a repository
+	// containing locked annex files is no longer handled by the server.
+	// The size number always refers to gigabytes.
+	LockedContentCutoffSize float64
 }
 
 // parseconfigvars loads all DOI server config vars from the
@@ -99,6 +103,14 @@ func parseconfigvars(cfg *Configuration) error {
 	}
 
 	cfg.Port = uint16(port)
+
+	cutsize, err := strconv.ParseFloat(libgin.ReadConfDefault("lockedcutoffsize", "250.0"), 64)
+	if err != nil {
+		log.Printf("Error while parsing locked content cutoff size flag: %s", err.Error())
+		log.Printf("Using default %.1f", 250.0)
+		cutsize = 250.0
+	}
+	cfg.LockedContentCutoffSize = cutsize
 
 	return nil
 }

--- a/cmd/gindoid/config.go
+++ b/cmd/gindoid/config.go
@@ -58,22 +58,10 @@ type Configuration struct {
 	}
 }
 
-// loadconfig reads all the configuration variables (from the environment).
-func loadconfig() (*Configuration, error) {
-	cfg := Configuration{}
-
-	// NOTE: Temporary workaround. GIN Client internals need a bit of a
-	// redesign to support in-memory configurations.
-	confdir := libgin.ReadConf("configdir")
-	confdir, err := filepath.Abs(confdir)
-	if err != nil {
-		return nil, err
-	}
-	err = os.Setenv("GIN_CONFIG_DIR", confdir)
-	if err != nil {
-		log.Printf("Could not set GIN_CONFIG_DIR env: %q", err.Error())
-	}
-
+// parseconfigvars loads all DOI server config vars from the
+// OS environment and handles default values and necessary
+// type conversions.
+func parseconfigvars(cfg *Configuration) error {
 	cfg.DOIBase = libgin.ReadConf("doibase")
 
 	cfg.Email.Server = libgin.ReadConf("mailserver")
@@ -107,13 +95,38 @@ func loadconfig() (*Configuration, error) {
 	portstr := libgin.ReadConfDefault("port", "10443")
 	port, err := strconv.ParseUint(portstr, 10, 16)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	cfg.Port = uint16(port)
 
-	// Set up GIN client configuration (for cloning)
+	return nil
+}
 
+// loadconfig reads all the configuration variables (from the environment).
+// It also creates and provides a gin client session to the specified
+// gin server.
+func loadconfig() (*Configuration, error) {
+	cfg := Configuration{}
+
+	// NOTE: Temporary workaround. GIN Client internals need a bit of a
+	// redesign to support in-memory configurations.
+	confdir := libgin.ReadConf("configdir")
+	confdir, err := filepath.Abs(confdir)
+	if err != nil {
+		return nil, err
+	}
+	err = os.Setenv("GIN_CONFIG_DIR", confdir)
+	if err != nil {
+		log.Printf("Could not set GIN_CONFIG_DIR env: %q", err.Error())
+	}
+
+	err = parseconfigvars(&cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set up GIN client configuration (for cloning)
 	ginurl := libgin.ReadConf("ginurl")
 	giturl := libgin.ReadConf("giturl")
 	log.Printf("gin: %s -- git: %s", ginurl, giturl)

--- a/cmd/gindoid/config_test.go
+++ b/cmd/gindoid/config_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLoadconfig(t *testing.T) {
+	// check 'configdir' env var
+	_, err := loadconfig()
+	if err == nil {
+		t.Fatal("Expected error on missing 'configdir' env var")
+	}
+
+	confpath := t.TempDir()
+	err = os.Setenv("configdir", confpath)
+	if err != nil {
+		t.Fatalf("Error setting 'confdir': %q", err.Error())
+	}
+
+	// check 'ginurl' env var
+	_, err = loadconfig()
+	if err == nil {
+		t.Fatal("Expected error on missing 'ginurl' env var")
+	} else if err != nil && !strings.Contains(err.Error(), "invalid web configuration") {
+		t.Fatalf("Error loading config: %q", err.Error())
+	}
+
+	err = os.Setenv("ginurl", "invalidurl")
+	if err != nil {
+		t.Fatalf("Error setting 'ginurl': %q", err.Error())
+	}
+	_, err = loadconfig()
+	if err == nil {
+		t.Fatal("Expected error on invalid 'ginurl' env var")
+	} else if err != nil && !strings.Contains(err.Error(), "invalid web configuration") {
+		t.Fatalf("Error loading config: %q", err.Error())
+	}
+}

--- a/cmd/gindoid/config_test.go
+++ b/cmd/gindoid/config_test.go
@@ -37,4 +37,31 @@ func TestLoadconfig(t *testing.T) {
 	} else if err != nil && !strings.Contains(err.Error(), "invalid web configuration") {
 		t.Fatalf("Error loading config: %q", err.Error())
 	}
+
+	// check invalid giturl
+	// we are not testing the gin-cli.config.ParseWebString here
+	err = os.Setenv("ginurl", "https://a.valid.url:1221")
+	if err != nil {
+		t.Fatalf("Error setting 'ginurl': %q", err.Error())
+	}
+	_, err = loadconfig()
+	if err == nil {
+		t.Fatal("Expected error on invalid 'giturl' env var")
+	} else if err != nil && !strings.Contains(err.Error(), "invalid git configuration") {
+		t.Fatalf("Error loading config: %q", err.Error())
+	}
+
+	// check error on invalid server setup
+	err = os.Setenv("giturl", "git@a.valid.url:2222")
+	if err != nil {
+		t.Fatalf("Error setting 'giturl': %q", err.Error())
+	}
+	_, err = loadconfig()
+	if err == nil {
+		t.Fatal("Expected error on invalid server configuration")
+	} else if err != nil && !strings.Contains(err.Error(), "no such host") {
+		t.Fatalf("Error loading config: %q", err.Error())
+	}
+
+	// further tests require a local git server.
 }

--- a/cmd/gindoid/config_test.go
+++ b/cmd/gindoid/config_test.go
@@ -13,6 +13,7 @@ func TestParseConfigVars(t *testing.T) {
 	defport := uint16(10443)
 	defqueue := 100
 	defwork := 3
+	defcutoff := 250.0
 
 	// test no error on basic load
 	err := parseconfigvars(&cfg)
@@ -99,6 +100,28 @@ func TestParseConfigVars(t *testing.T) {
 		t.Fatalf("Unexpected maxworkers error: %q", err.Error())
 	} else if cfg.MaxWorkers != 5 {
 		t.Fatalf("Unexpected maxworkers value: %d", cfg.MaxWorkers)
+	}
+
+	// check cutoff size entry handling
+	if err = os.Setenv("lockedcutoffsize", "abc"); err != nil {
+		t.Fatalf("Error setting 'cutoff': %q", err.Error())
+	}
+	err = parseconfigvars(&cfg)
+	if err != nil {
+		t.Fatalf("Unexpected cutoff error: %q", err.Error())
+	} else if cfg.LockedContentCutoffSize != defcutoff {
+		t.Fatalf("Unexpected cutoff default value: %.1f", cfg.LockedContentCutoffSize)
+	}
+
+	// valid entry
+	if err = os.Setenv("lockedcutoffsize", "5"); err != nil {
+		t.Fatalf("Error re-setting 'cutoff': %q", err.Error())
+	}
+	err = parseconfigvars(&cfg)
+	if err != nil {
+		t.Fatalf("Unexpected cutoff error: %q", err.Error())
+	} else if cfg.LockedContentCutoffSize != 5 {
+		t.Fatalf("Unexpected cutoff value: %.1f", cfg.LockedContentCutoffSize)
 	}
 
 	// test no panic on unset variables

--- a/cmd/gindoid/config_test.go
+++ b/cmd/gindoid/config_test.go
@@ -177,6 +177,20 @@ func TestLoadconfig(t *testing.T) {
 		t.Fatalf("Error setting 'confdir': %q", err.Error())
 	}
 
+	// check error on invalid port
+	if err = os.Setenv("port", "abc"); err != nil {
+		t.Fatalf("Error setting 'port': %q", err.Error())
+	}
+	_, err = loadconfig()
+	if err == nil {
+		t.Fatal("Expected error on invalid port entry")
+	} else if err != nil && !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Unexpected port error: %q", err.Error())
+	}
+	if err = os.Setenv("port", "12"); err != nil {
+		t.Fatalf("Error setting 'port': %q", err.Error())
+	}
+
 	// check 'ginurl' env var
 	_, err = loadconfig()
 	if err == nil {

--- a/cmd/gindoid/config_test.go
+++ b/cmd/gindoid/config_test.go
@@ -6,6 +6,141 @@ import (
 	"testing"
 )
 
+func TestParseConfigVars(t *testing.T) {
+	cfg := Configuration{}
+
+	// might be a better way to test server default values
+	defport := uint16(10443)
+	defqueue := 100
+	defwork := 3
+
+	// test no error on basic load
+	err := parseconfigvars(&cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %q", err.Error())
+	}
+
+	// test default values in config
+	if cfg.Port != defport || cfg.MaxQueue != defqueue || cfg.MaxWorkers != defwork {
+		t.Fatalf("Encountered unexpected default value(s): port (%d), queue (%d), workers (%d)", cfg.Port, cfg.MaxQueue, cfg.MaxWorkers)
+	}
+
+	// test invalid port entry handling
+	if err = os.Setenv("port", "abc"); err != nil {
+		t.Fatalf("Error setting 'port': %q", err.Error())
+	}
+	err = parseconfigvars(&cfg)
+	if err == nil {
+		t.Fatal("Expected error on invalid port entry")
+	} else if err != nil && !strings.Contains(err.Error(), "invalid syntax") {
+		t.Fatalf("Unexpected port error: %q", err.Error())
+	}
+
+	if err = os.Setenv("port", "500000000"); err != nil {
+		t.Fatalf("Error re-setting invalid 'port': %q", err.Error())
+	}
+	err = parseconfigvars(&cfg)
+	if err == nil {
+		t.Fatal("Expected error on invalid port entry")
+	} else if err != nil && !strings.Contains(err.Error(), "value out of range") {
+		t.Fatalf("Unexpected port error: %q", err.Error())
+	}
+
+	if err = os.Setenv("port", "12"); err != nil {
+		t.Fatalf("Error re-setting valid 'port': %q", err.Error())
+	}
+	err = parseconfigvars(&cfg)
+	if err != nil {
+		t.Fatalf("Unexpected port set error: %q", err.Error())
+	}
+	if cfg.Port != 12 {
+		t.Fatalf("Expected port '12' but got %d", cfg.Port)
+	}
+
+	// test maxqueue entry handling
+	if err = os.Setenv("maxqueue", "abc"); err != nil {
+		t.Fatalf("Error setting 'maxqueue': %q", err.Error())
+	}
+	err = parseconfigvars(&cfg)
+	if err != nil {
+		t.Fatalf("Unexpected maxqueue error: %q", err.Error())
+	} else if cfg.MaxQueue != defqueue {
+		t.Fatalf("Unexpected maxqueue default value: %d", cfg.MaxQueue)
+	}
+
+	// valid entry
+	if err = os.Setenv("maxqueue", "50"); err != nil {
+		t.Fatalf("Error re-setting 'maxqueue': %q", err.Error())
+	}
+	err = parseconfigvars(&cfg)
+	if err != nil {
+		t.Fatalf("Unexpected maxqueue error: %q", err.Error())
+	} else if cfg.MaxQueue != 50 {
+		t.Fatalf("Unexpected maxqueue value: %d", cfg.MaxQueue)
+	}
+
+	// check maxworkers entry handling
+	if err = os.Setenv("maxworkers", "abc"); err != nil {
+		t.Fatalf("Error setting 'maxworkers': %q", err.Error())
+	}
+	err = parseconfigvars(&cfg)
+	if err != nil {
+		t.Fatalf("Unexpected maxworkers error: %q", err.Error())
+	} else if cfg.MaxWorkers != defwork {
+		t.Fatalf("Unexpected maxworkers default value: %d", cfg.MaxWorkers)
+	}
+
+	// valid entry
+	if err = os.Setenv("maxworkers", "5"); err != nil {
+		t.Fatalf("Error re-setting 'maxworkers': %q", err.Error())
+	}
+	err = parseconfigvars(&cfg)
+	if err != nil {
+		t.Fatalf("Unexpected maxworkers error: %q", err.Error())
+	} else if cfg.MaxWorkers != 5 {
+		t.Fatalf("Unexpected maxworkers value: %d", cfg.MaxWorkers)
+	}
+
+	// test no panic on unset variables
+	// check access of all config field after loading
+	if cfg.DOIBase != "" {
+		t.Fatalf("Unexpected DOIbase %q", cfg.DOIBase)
+	}
+	if cfg.Key != "" {
+		t.Fatalf("Unexpected Key %q", cfg.Key)
+	}
+	if cfg.XMLRepo != "" {
+		t.Fatalf("Unexpected XMLRepo %q", cfg.XMLRepo)
+	}
+	if cfg.Email.Server != "" {
+		t.Fatalf("Unexpected Email.Server %q", cfg.Email.Server)
+	}
+	if cfg.Email.From != "" {
+		t.Fatalf("Unexpected Email.From %q", cfg.Email.From)
+	}
+	if cfg.Email.RecipientsFile != "" {
+		t.Fatalf("Unexpected Email.RecipientsFile %q", cfg.Email.RecipientsFile)
+	}
+	if cfg.GIN.Password != "" {
+		t.Fatalf("Unexpected GIN.Password %q", cfg.GIN.Password)
+	}
+	if cfg.GIN.Username != "" {
+		t.Fatalf("Unexpected GIN.Username %q", cfg.GIN.Username)
+	}
+	if cfg.Storage.PreparationDirectory != "" {
+		t.Fatalf("Unexpected prep dir %q", cfg.Storage.PreparationDirectory)
+	}
+	if cfg.Storage.StoreURL != "" {
+		t.Fatalf("Unexpected StoreURL %q", cfg.Storage.StoreURL)
+	}
+	if cfg.Storage.TargetDirectory != "" {
+		t.Fatalf("Unexpected TargetDirectory %q", cfg.Storage.TargetDirectory)
+	}
+	if cfg.Storage.XMLURL != "" {
+		t.Fatalf("Unexpected XMLURL %q", cfg.Storage.XMLURL)
+	}
+}
+
 func TestLoadconfig(t *testing.T) {
 	// check 'configdir' env var
 	_, err := loadconfig()

--- a/cmd/gindoid/dataset.go
+++ b/cmd/gindoid/dataset.go
@@ -141,7 +141,7 @@ func createRegisteredDataset(job *RegistrationJob) error {
 // If the size is above the specified threshold or if any issue arises
 // during the clone and unlock procedure, the function stops and returns
 // an appropriate error.
-func handleLockedAnnex(preppath, repodir, reponame string) (string, error) {
+func handleLockedAnnex(preppath, repodir, reponame string, cutoff float64) (string, error) {
 	reposize, err := annexSize(repodir)
 	if err != nil {
 		return "", fmt.Errorf("error reading annex size %q", err.Error())
@@ -150,7 +150,7 @@ func handleLockedAnnex(preppath, repodir, reponame string) (string, error) {
 	// check if the repo is eligible for local clone and unlock;
 	// repos above a certain size threshold should not be automatically
 	// cloned a second time locally.
-	if !acceptedAnnexSize(reposize) {
+	if !acceptedAnnexSize(reposize, cutoff) {
 		return "", fmt.Errorf("unsupported repo size (%s)", reposize)
 	}
 
@@ -232,7 +232,7 @@ func cloneAndZip(repopath string, jobname string, preppath string, targetpath st
 
 		// overwrite the "repodir" variable with the directory of the cloned
 		// repository containing the unlocked annex content.
-		repodir, err = handleLockedAnnex(preppath, repodir, reponame)
+		repodir, err = handleLockedAnnex(preppath, repodir, reponame, conf.LockedContentCutoffSize)
 		if err != nil {
 			log.Printf("Skipping zip creation; %s", err.Error())
 			return "", -1, fmt.Errorf("%d locked annex files; skipping zip creation; %s", len(splitlock), err.Error())

--- a/cmd/gindoid/mail_test.go
+++ b/cmd/gindoid/mail_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/G-Node/libgin/libgin"
+)
+
+func TestNotifyAdminContent(t *testing.T) {
+	// if any of these is not properly initialized,
+	// the function will panic.
+	testjob := &RegistrationJob{}
+	testjob.Config = &Configuration{}
+	testjob.Metadata = &libgin.RepositoryMetadata{}
+	datacite := libgin.NewDataCite()
+	testjob.Metadata.DataCite = &datacite
+	testjob.Metadata.RequestingUser = &libgin.GINUser{}
+
+	var errlist []string
+	var warnlist []string
+	var full bool
+	var chash string
+
+	subjbase := "New DOI registration request: "
+	noissuestxt := "no issues have been found"
+
+	// A) Test 'no issues' subject and body
+	body, subj := notifyAdminContent(testjob, errlist, warnlist, full, chash)
+	if subj != subjbase {
+		t.Fatalf("Unexpected subject: %q", subj)
+	}
+	if !strings.Contains(body, noissuestxt) {
+		t.Fatalf("Unexpected body: %q", body)
+	}
+
+	// B) Test errors and warnings subject and body
+	// Test 'errors' only subject and body
+	errbody := "errors occurred"
+	warnbody := "issues were detected"
+
+	erritem := "An error was found"
+	errlist = append(errlist, erritem)
+	body, subj = notifyAdminContent(testjob, errlist, warnlist, full, chash)
+	if subj != subjbase {
+		t.Fatalf("Unexpected subject: %q", subj)
+	}
+	if !strings.Contains(body, erritem) || !strings.Contains(body, errbody){
+		t.Fatalf("Error missing in body: %q", body)
+	} else if strings.Contains(body, warnbody) {
+		t.Fatalf("Unexpected warning in body: %q", body)
+	}
+
+	// Test 'warnings' only subject and body
+	errlist = []string{}
+	warnitem := "An error was found"
+	warnlist = append(warnlist, warnitem)
+	warnlist = append(warnlist, warnitem)
+	body, subj = notifyAdminContent(testjob, errlist, warnlist, full, chash)
+	if subj != subjbase {
+		t.Fatalf("Unexpected subject: %q", subj)
+	}
+	if !strings.Contains(body, warnitem) || !strings.Contains(body, warnbody) || !strings.Contains(body, "2.") {
+		t.Fatalf("Warning missing in body: %q", body)
+	} else if strings.Contains(body, errbody) {
+		t.Fatalf("Unexpected error in body: %q", body)
+	}
+
+	// Test 'errors' and 'warnings' subject and body
+	errlist = append(errlist, erritem)
+	body, subj = notifyAdminContent(testjob, errlist, warnlist, full, chash)
+	if subj != subjbase {
+		t.Fatalf("Unexpected subject: %q", subj)
+	}
+	if !strings.Contains(body, warnitem) || !strings.Contains(body, warnbody) || !strings.Contains(body, "2.") {
+		t.Fatalf("Warning missing in body: %q", body)
+	} else if !strings.Contains(body, erritem) || !strings.Contains(body, errbody){
+		t.Fatalf("Error missing in body: %q", body)
+	}
+
+	// C) Test 'full' notification subject and Body
+	errlist = []string{}
+	warnlist = []string{}
+	full = true
+
+	// test no panic on empty entries
+	_, _ = notifyAdminContent(testjob, errlist, warnlist, full, chash)
+
+	// test id in subject
+	sourcerepo := "source_repo"
+	testjob.Metadata.SourceRepository = sourcerepo
+	_, subj = notifyAdminContent(testjob, errlist, warnlist, full, chash)
+	if !strings.HasPrefix(subj, subjbase) || !strings.Contains(subj, sourcerepo) {
+		t.Fatalf("Unexpected subject: %q", subj)
+	}
+
+	// test urljoin
+	testjob.Config.Storage.StoreURL = "https://storage_url.org/"
+	testjob.Metadata.Identifier.ID = "/job/id"
+	body, _ = notifyAdminContent(testjob, errlist, warnlist, full, chash)
+	if !strings.Contains(body, "new DOI registration") || !strings.Contains(body, "DOI target URL: https://storage_url.org/job/id") {
+		t.Fatalf("Unexpected body: %q", body)
+	}
+}

--- a/cmd/gindoid/mail_test.go
+++ b/cmd/gindoid/mail_test.go
@@ -45,7 +45,7 @@ func TestNotifyAdminContent(t *testing.T) {
 	if subj != subjbase {
 		t.Fatalf("Unexpected subject: %q", subj)
 	}
-	if !strings.Contains(body, erritem) || !strings.Contains(body, errbody){
+	if !strings.Contains(body, erritem) || !strings.Contains(body, errbody) {
 		t.Fatalf("Error missing in body: %q", body)
 	} else if strings.Contains(body, warnbody) {
 		t.Fatalf("Unexpected warning in body: %q", body)
@@ -74,7 +74,7 @@ func TestNotifyAdminContent(t *testing.T) {
 	}
 	if !strings.Contains(body, warnitem) || !strings.Contains(body, warnbody) || !strings.Contains(body, "2.") {
 		t.Fatalf("Warning missing in body: %q", body)
-	} else if !strings.Contains(body, erritem) || !strings.Contains(body, errbody){
+	} else if !strings.Contains(body, erritem) || !strings.Contains(body, errbody) {
 		t.Fatalf("Error missing in body: %q", body)
 	}
 

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -757,9 +757,9 @@ func unlockAnnexClone(reponame, gitcloneroot, gitrepodir string) (string, error)
 // and the size is below the supported threshold (currently 250.0 gigabytes)
 // the function returns true. In any other case including parsing issues,
 // the function returns false.
-func acceptedAnnexSize(annexSize string) bool {
+func acceptedAnnexSize(annexSize string, cutoff float64) bool {
 	// acceptedGigaSize might be moved outside to become a server setting
-	acceptedGigaSize := 250.0
+	acceptedGigaSize := cutoff
 
 	sizesplit := strings.Split(annexSize, " ")
 	if len(sizesplit) != 2 {

--- a/cmd/gindoid/util.go
+++ b/cmd/gindoid/util.go
@@ -134,6 +134,11 @@ func EscXML(txt string) string {
 // GetGINURL returns the full URL to the configured GIN server. If it's
 // configured with a non-standard port, the port number is included.
 func GetGINURL(conf *Configuration) string {
+	// something went wrong, but do not panic
+	if conf.GIN.Session == nil {
+		log.Println("Missing GIN session, return empty GINURL")
+		return ""
+	}
 	address := conf.GIN.Session.WebAddress()
 	// get scheme
 	schemeSepIdx := strings.Index(address, "://")

--- a/cmd/gindoid/util_test.go
+++ b/cmd/gindoid/util_test.go
@@ -764,46 +764,46 @@ func TestUnlockAnnexClone(t *testing.T) {
 
 func TestAcceptedAnnexSize(t *testing.T) {
 	// check empty string
-	if acceptedAnnexSize("") {
+	if acceptedAnnexSize("", 250) {
 		t.Fatal("True on empty string")
 	}
 
 	// check non-splitable string
-	if acceptedAnnexSize("100kilobytes") {
+	if acceptedAnnexSize("100kilobytes", 250) {
 		t.Fatal("True on invalid string")
 	}
 
 	// check unsupported 'unit'
-	if acceptedAnnexSize("10.4 petabytes") {
+	if acceptedAnnexSize("10.4 petabytes", 250) {
 		t.Fatal("True on unsupported unit petabytes")
 	}
 
 	// check non parseable size with threshold unit gigabytes
-	if acceptedAnnexSize("doesnotconverttofloat gigabytes") {
+	if acceptedAnnexSize("doesnotconverttofloat gigabytes", 250) {
 		t.Fatal("True on non-parsable size")
 	}
 
 	// check supported units
-	if !acceptedAnnexSize("10.4 bytes") {
+	if !acceptedAnnexSize("10.4 bytes", 250) {
 		t.Fatal("False on bytes")
 	}
-	if !acceptedAnnexSize("10.4 kilobytes") {
+	if !acceptedAnnexSize("10.4 kilobytes", 250) {
 		t.Fatal("False on kilobytes")
 	}
-	if !acceptedAnnexSize("10.4 megabytes") {
+	if !acceptedAnnexSize("10.4 megabytes", 250) {
 		t.Fatal("False on megabytes")
 	}
 
 	// check supported unit and supported size
-	if !acceptedAnnexSize("10.4 gigabytes") {
+	if !acceptedAnnexSize("10.4 gigabytes", 250) {
 		t.Fatal("False on allowed gigabytes")
 	}
 
 	// check supported unit and unsupported size
-	if acceptedAnnexSize("250.1 gigabytes") {
+	if acceptedAnnexSize("250.1 gigabytes", 250) {
 		t.Fatal("True on unsupported size")
 	}
-	if acceptedAnnexSize("1 terabytes") {
+	if acceptedAnnexSize("1 terabytes", 250) {
 		t.Fatal("True on terabyte")
 	}
 }

--- a/cmd/gindoid/web_test.go
+++ b/cmd/gindoid/web_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"html/template"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -47,5 +49,18 @@ func TestInjectDynamicGINURL(t *testing.T) {
 	}
 	if checkurl != b.String() {
 		t.Fatalf("Error dynamic URL; got: '%s'", b.String())
+	}
+}
+
+func TestRenderResult(t *testing.T) {
+	cfg := Configuration{}
+	resData := reqResultData{}
+	w := httptest.NewRecorder()
+
+	renderResult(w, &resData, &cfg)
+
+	content := w.Body.Bytes()
+	if !strings.Contains(string(content), "DOI request failed") {
+		t.Fatal("Did not retrieve DOI request fail page")
 	}
 }

--- a/version
+++ b/version
@@ -1,1 +1,1 @@
-version=0.6
+version=0.7


### PR DESCRIPTION
This PR prepares for a new release (v0.7) of the gin-doi server.

- a potential panic in the `util.GetGINURL` function is caught.
- functions in config and dataset have been refactored; the locked annex content cutoff size can now be defined via the os environment variable `lockedcutoffsize`. Default size is 250.0 GB. This closes #127.
- the `loadconfig` function has been refactored to allow partial testing.
- additional tests are added.
